### PR TITLE
Fix WorkloadView filter: ignore unassigned click and toggle user filter

### DIFF
--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -339,7 +339,13 @@ export function BoardPage({ projectId, onNavigate }: BoardPageProps) {
         return (
           <WorkloadView
             projectId={projectId}
-            onFilterByUser={(userId) => setFilters((prev) => ({ ...prev, assignee_id: userId }))}
+            onFilterByUser={(userId) => {
+              if (userId === 'unassigned') return;
+              setFilters((prev) => ({
+                ...prev,
+                assignee_id: prev.assignee_id === userId ? undefined : userId,
+              }));
+            }}
           />
         );
 


### PR DESCRIPTION
The onFilterByUser callback in WorkloadView had two bugs:
1. Clicking the "unassigned" bucket would set assignee_id to the literal string 'unassigned', producing broken filter results.
2. Clicking the same user twice would not clear the filter — there was no toggle behavior, so users had no way to deselect a workload filter once applied.

Now guards against the 'unassigned' userId and toggles the filter off when clicking the already-active user.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>