### PR TITLE
Wave 0.4: Event naming sweep + migration 0072 (P0.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,7 +283,7 @@ pnpm --filter @bigbluebam/banter test        # Banter frontend component tests (
 - **WebSocket realtime** uses Redis PubSub for cross-instance broadcasting; rooms are scoped to org, project, and user levels.
 - **Keyboard shortcuts** and a **command palette** (Cmd+K) are built into the frontend for power-user navigation.
 - **User and member management** is consolidated at `/b3/people` (org admins/owners) and `/b3/superuser/people` (platform SuperUsers) — not under Settings — with tabbed user-detail pages covering profile, projects, access (API keys/sessions/passwords), and activity.
-- **Bond stale-deal detection** runs as a daily 2 AM UTC worker job that finds deals where `days_in_stage > rotting_days` and emits `bond.deal.rotting` events to Bolt ingest; `bond_deals.rotting_alerted_at` is the per-stage-entry idempotency marker (reset naturally when `stage_entered_at` changes).
+- **Bond stale-deal detection** runs as a daily 2 AM UTC worker job that finds deals where `days_in_stage > rotting_days` and emits `deal.rotting` events (source `bond`) to Bolt ingest; `bond_deals.rotting_alerted_at` is the per-stage-entry idempotency marker (reset naturally when `stage_entered_at` changes).
 
 ## Error Response Envelope
 

--- a/apps/worker/src/jobs/bond-stale-deals.job.ts
+++ b/apps/worker/src/jobs/bond-stale-deals.job.ts
@@ -3,8 +3,8 @@
  *
  * Finds open deals whose time-in-stage has exceeded `bond_pipeline_stages.rotting_days`
  * and which have not yet been alerted for the current stage entry, emits a
- * `bond.deal.rotting` event to Bolt for each one, and marks the deal with
- * `rotting_alerted_at = NOW()` so the same stage-entry is not re-alerted.
+ * `deal.rotting` event (source: `bond`) to Bolt for each one, and marks the deal
+ * with `rotting_alerted_at = NOW()` so the same stage-entry is not re-alerted.
  *
  * Idempotency model:
  *   - A deal is considered newly stale if either
@@ -111,9 +111,8 @@ export async function processBondStaleDealsJob(
     try {
       // Fire-and-forget event emission. publishBoltEvent never throws, so
       // this await will resolve cleanly whether the POST succeeded or not.
-      // event name normalized in wave 0.4
       await publishBoltEvent(
-        'bond.deal.rotting',
+        'deal.rotting',
         'bond',
         {
           deal_id: row.id,

--- a/apps/worker/test/bond-stale-deals.test.ts
+++ b/apps/worker/test/bond-stale-deals.test.ts
@@ -58,7 +58,7 @@ describe('Bond Stale Deals Job', () => {
     );
   });
 
-  it('emits bond.deal.rotting and updates rotting_alerted_at for each stale deal', async () => {
+  it('emits deal.rotting and updates rotting_alerted_at for each stale deal', async () => {
     const staleRows = [
       {
         id: 'deal-1',
@@ -104,7 +104,7 @@ describe('Bond Stale Deals Job', () => {
     expect(publishBoltEvent).toHaveBeenCalledTimes(3);
     expect(publishBoltEvent).toHaveBeenNthCalledWith(
       1,
-      'bond.deal.rotting',
+      'deal.rotting',
       'bond',
       {
         deal_id: 'deal-1',
@@ -119,7 +119,7 @@ describe('Bond Stale Deals Job', () => {
     );
     expect(publishBoltEvent).toHaveBeenNthCalledWith(
       3,
-      'bond.deal.rotting',
+      'deal.rotting',
       'bond',
       expect.objectContaining({ deal_id: 'deal-3' }),
       'org-b',

--- a/docs/plans/2026-04-13-revised/DECISIONS.md
+++ b/docs/plans/2026-04-13-revised/DECISIONS.md
@@ -154,3 +154,37 @@ Context: user authorized autonomous execution before bed with the note "use your
 
 **Revert.** Remove `continue-on-error: true` from the apps typecheck step once every apps package is strict-clean. Until then, any Wave 2 per-app plan can narrow the `--filter='!...'` exclusion list to promote its package into the strict step.
 
+## D-011: Wave 0.4 sub-decisions for the event-naming sweep (2026-04-14 overnight)
+
+**Decision.** Three small calls made while executing Wave 0 item 0.4 (event-naming sweep + migration 0072 + drift-guard script extension), each within scope but worth recording. (D-009 and D-010 are reserved by parallel Wave 0 worktrees; D-011 was assigned by the orchestration brief.)
+
+### D-011a: Migration 0072 handles `bolt_executions.trigger_event` as jsonb, not text
+
+**Decision.** The plan's migration template (Cross_Product_Integration_Plan.md lines 685-708) writes `bolt_executions.trigger_event` and `bolt_automations.trigger_event` as if both were text columns. They are not. `apps/bolt-api/src/db/schema/bolt-executions.ts:30` declares `trigger_event` as `jsonb('trigger_event')`, and `apps/bolt-api/src/routes/event-ingestion.routes.ts` writes the full payload `{ ...event.payload, _event_id, _source, _event_type }` into it. The event-type string we want to rewrite lives under the `_event_type` key, not the column root. I rewrote 0072's second UPDATE to use `jsonb_set(trigger_event, '{_event_type}', '"deal.rotting"'::jsonb, false)` with a `WHERE trigger_event->>'_event_type' = 'bond.deal.rotting'` predicate (which naturally skips NULL rows and rows where the key is absent). The first UPDATE on `bolt_automations.trigger_event` (varchar(60), NOT NULL per `bolt-automations.ts:45`) stays as the plan template wrote it.
+
+**Why.** The plan's text version would silently no-op against `bolt_executions` (because no row's full jsonb object equals the bare string `'bond.deal.rotting'`) and the historical execution rows would carry the wrong `_event_type` forever. jsonb_set with predicate-on-key is the minimal change that does what the plan intended.
+
+**Alternatives.** Skip the executions table entirely and only fix automations (rejected: the plan explicitly names `bolt_executions` as a target, and historical execution rows are exactly what the plan wants to normalize). Cast trigger_event to text and string-replace (rejected: brittle, would corrupt nested values that contain the substring). Add a migration that backfills a separate `event_type` column (rejected: scope expansion and schema change for what the plan said is a string rewrite).
+
+**Revert.** Drop migration 0072. Existing rows revert to the legacy `_event_type: 'bond.deal.rotting'`. Bolt rule authors that target `deal.rotting` would miss historical executions, but no data is lost.
+
+### D-011b: `scripts/check-bolt-catalog.mjs` is created in this PR, not extended
+
+**Decision.** The brief says to "extend" the existing `scripts/check-bolt-catalog.mjs` with the two new sweep assertions. The script does not exist on `feature-completion-wip` after Waves 0.1 / 0.2 / 0.3, neither under `scripts/` nor anywhere else, and no `check:bolt` script is wired into the root `package.json`. Wave 0.1's plan §2.1 referenced creating it but the implementing PR (#5) did not land it. I created the script fresh in `scripts/check-bolt-catalog.mjs` with the two assertions the brief asks for (R1 = first arg is a string literal; R2 = first arg is not in the deny-list `PREFIXED_BAD_NAMES`; R3 = second arg is a string literal in the BoltEventSource enum) and wired `pnpm check:bolt-catalog` into root `package.json`. Catalog presence (the original §2.1 responsibility) is NOT implemented here; it remains the §2.1 owner's responsibility because doing it now would require parsing `apps/bolt-api/src/services/event-catalog.ts` and choosing a coverage policy, which is scope creep beyond P0.3.
+
+**Why.** The brief's instruction "extend it rather than rewriting it" assumed the script existed. Reality is a hard dependency: I either create the file or block on a Wave 0.1 follow-up that may not happen. Creating just the two P0.3 assertions keeps the PR's scope tight and gives Wave 0.1 a hook to drop catalog-presence checks into when that work happens. The script is structured so adding catalog-presence is a single new function call in `main()` after the existing per-call rules.
+
+**Alternatives.** Do nothing and document the gap (rejected: the plan explicitly requires the assertions to exist and run in CI). Wait for §2.1 (rejected: §2.1 may not be on the Wave 0 critical path and the user authorized autonomous progress). Inline the assertions into `lint-migrations.mjs` (rejected: that script is migration-scoped and conflating concerns hides the rule).
+
+**Revert.** Delete `scripts/check-bolt-catalog.mjs` and remove the `check:bolt-catalog` script from `package.json`. The two assertions revert to grep-based ad-hoc checks.
+
+### D-011c: PREFIXED_BAD_NAMES is an exact-match deny-list, not a regex on source-prefix
+
+**Decision.** The plan's first sweep grep is heuristic: `publishBoltEvent\(\s*['\"](bam|...|bond|...)\.` matches any event whose first token matches a known service name. That heuristic produces false positives for legitimate canonical names where the entity domain and the source service share a word (e.g. `beacon.created`, `board.updated`, `bolt.execution_completed` if any existed). The plan itself acknowledges this in §660: the catalog "vast majority" uses `beacon.created`-style bare names that the heuristic would incorrectly flag. I implemented R2 as an exact-match deny-list (`PREFIXED_BAD_NAMES = new Set(['bond.deal.rotting'])`) rather than a regex on the source-prefix list. New bad names get added to the set explicitly when a regression is found.
+
+**Why.** A regex-based check would have to enumerate every legitimate name as an exception list, which is exactly the catalog presence check that the plan defers to §2.1. Until the catalog is wired in, an explicit deny-list is the only false-positive-free option. The deny-list is currently length 1 (only `bond.deal.rotting`); the plan asserts that is the only known prefixed name. If a future audit finds another, the fix is one line added to the set.
+
+**Alternatives.** Regex with a deny-list of legitimate names (rejected: maintenance burden and duplicates the catalog). Wait for the catalog wiring to land in §2.1 (rejected: blocks Wave 0.4 indefinitely). Block on every name starting with a source word and force authors to opt out per call site (rejected: extreme false positive rate against current bare-canonical names).
+
+**Revert.** Replace the `PREFIXED_BAD_NAMES` set with a regex against `KNOWN_SOURCES`. The set of bare canonical names that share a domain with a service name (`beacon.*`, `board.*`, `bolt.*` if any) become R2 violations and the script exits 1 until they are catalog-listed.
+

--- a/docs/plans/2026-04-13-revised/MIGRATION_LEDGER.md
+++ b/docs/plans/2026-04-13-revised/MIGRATION_LEDGER.md
@@ -24,7 +24,7 @@ Authoritative registry of migration numbers reserved for the 2026-04-13 implemen
 
 | Number | File | Plan | Wave item | Status |
 |---|---|---|---|---|
-| 0072 | `0072_bolt_rename_prefixed_events.sql` | Cross-Product | Wave 0 item 4 | pending |
+| 0072 | `0072_bolt_rename_prefixed_events.sql` | Cross-Product | Wave 0 item 4 | claimed (Wave 0.4) |
 | 0075 | `0075_enable_rls_core_tables.sql` | Platform | Wave 1 item 1 | pending |
 | 0077 | `0077_api_key_rotation.sql` | Platform | Wave 1 item 1 | pending |
 | 0078 | `0078_reconcile_bam_bearing_drift.sql` | Platform | Wave 0.1 item 1 (PR #5 second follow-up) | in-review |

--- a/infra/postgres/migrations/0072_bolt_rename_prefixed_events.sql
+++ b/infra/postgres/migrations/0072_bolt_rename_prefixed_events.sql
@@ -1,0 +1,44 @@
+-- 0072_bolt_rename_prefixed_events.sql
+-- Why: Normalize event-type strings to bare names after the Wave 0.4
+--   cross-product naming sweep. Bond's stale-deal worker previously
+--   emitted 'bond.deal.rotting'; every other catalog entry is bare
+--   (deal.created, board.updated, beacon.verified, etc.). This
+--   migration rewrites the two persisted columns that could hold a
+--   historical prefixed value: bolt_automations.trigger_event (text)
+--   and bolt_executions.trigger_event (jsonb, with _event_type key).
+--   See Cross_Product_Integration_Plan.md Step 4 (P0.3) and
+--   DECISIONS.md D-011 for context.
+-- Client impact: additive only. String rewrites on two existing
+--   columns; no schema change, no row creation, no row deletion. Safe
+--   to re-run (second run's WHERE clause matches zero rows).
+
+BEGIN;
+
+-- 1. bolt_automations.trigger_event (varchar(60), NOT NULL)
+--    Matches the exact legacy string on equality.
+UPDATE bolt_automations
+SET trigger_event = 'deal.rotting'
+WHERE trigger_event = 'bond.deal.rotting';
+
+-- 2. bolt_executions.trigger_event (jsonb, nullable)
+--    The column stores the full trigger payload; the event-type string
+--    lives under the `_event_type` key, set by
+--    apps/bolt-api/src/routes/event-ingestion.routes.ts at ingest time.
+--    jsonb_set returns the same object with that key replaced.
+--    The WHERE clause uses ->> for a text comparison so rows where the
+--    key is absent or NULL are naturally skipped.
+UPDATE bolt_executions
+SET trigger_event = jsonb_set(
+    trigger_event,
+    '{_event_type}',
+    '"deal.rotting"'::jsonb,
+    false
+)
+WHERE trigger_event IS NOT NULL
+  AND trigger_event->>'_event_type' = 'bond.deal.rotting';
+
+-- No further prefixed names were found by the Wave 0.4 sweep. If future
+-- incidents surface additional rewrites, claim a new migration number
+-- rather than editing this file.
+
+COMMIT;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "db:migrate": "docker compose run --rm migrate",
     "db:check": "node scripts/db-check.mjs",
     "lint:migrations": "node scripts/lint-migrations.mjs",
+    "check:bolt-catalog": "node scripts/check-bolt-catalog.mjs",
     "db:generate": "pnpm --filter @bigbluebam/api db:generate",
     "db:push": "pnpm --filter @bigbluebam/api db:push"
   },

--- a/scripts/check-bolt-catalog.mjs
+++ b/scripts/check-bolt-catalog.mjs
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+// check-bolt-catalog.mjs
+//
+// Wave 0.4 / Cross_Product_Integration_Plan.md Step 4 (P0.3) drift guard.
+//
+// Enforces the naming convention sweep and signature invariants for every
+// publishBoltEvent call site across apps/ and packages/. The plan text says
+// this script was intended to be a §2.1 (Wave 0.1) artifact and extended
+// here; in practice it did not exist when Wave 0.4 opened, so it is created
+// in this commit. See DECISIONS.md D-011.
+//
+// Rules enforced (any violation exits 1):
+//
+//   R1  First positional arg must be a string literal.
+//       Rationale: dynamic event types defeat the catalog/drift guard.
+//
+//   R2  First positional arg must be a bare event name (no source-service
+//       prefix). The canonical form is `<domain>.<action>` (e.g.
+//       'deal.rotting', 'task.created', 'comment.created'). Legitimate
+//       names where the domain happens to equal a source name (e.g.
+//       'beacon.created', 'board.updated') are allowed because they are
+//       the catalog-canonical form. Only exact-match prefixed names in
+//       PREFIXED_BAD_NAMES are rejected.
+//
+//       Keep the deny-list explicit. Adding a new known-bad name here is
+//       the right place to catch future regressions without false-positive
+//       cascades on the many legitimate bare names that start with a
+//       source-service word.
+//
+//   R3  Second positional arg must be a string literal equal to one of
+//       the BoltEventSource values declared in
+//       packages/shared/src/bolt-events.ts (= BoltEventSource union).
+//       Rationale: Zod validates `source` at the ingest route against
+//       the same enum; drift here produces runtime 400s on ingest.
+//
+// Usage: node scripts/check-bolt-catalog.mjs
+// Exit:  0 on clean, 1 on any violation.
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+// Keep in sync with packages/shared/src/bolt-events.ts BoltEventSource.
+const KNOWN_SOURCES = new Set([
+  'bam',
+  'banter',
+  'beacon',
+  'bearing',
+  'bench',
+  'bill',
+  'blank',
+  'blast',
+  'board',
+  'bolt',
+  'bond',
+  'book',
+  'brief',
+  'helpdesk',
+  'schedule',
+]);
+
+// Explicit deny-list of legacy prefixed event names. Add a new entry here
+// when a new service introduces a wrongly-prefixed name. The entry should
+// be the exact literal value that appears in source, minus the quotes.
+const PREFIXED_BAD_NAMES = new Set([
+  'bond.deal.rotting',
+]);
+
+// Directories to scan. Kept short and explicit so the script has no
+// accidental surface-area growth when new top-level folders appear.
+const SCAN_ROOTS = ['apps', 'packages'];
+
+// File filter: only .ts, skip tests, skip .d.ts, skip the implementation
+// file (packages/shared/src/bolt-events.ts defines the function, not a
+// call site).
+function isScanCandidate(absPath) {
+  if (!absPath.endsWith('.ts')) return false;
+  if (absPath.endsWith('.d.ts')) return false;
+  const rel = relative(ROOT, absPath).replace(/\\/g, '/');
+  if (rel.includes('/test/')) return false;
+  if (rel.includes('/tests/')) return false;
+  if (rel.endsWith('.test.ts')) return false;
+  if (rel.endsWith('.spec.ts')) return false;
+  if (rel === 'packages/shared/src/bolt-events.ts') return false;
+  if (rel.includes('/node_modules/')) return false;
+  if (rel.includes('/dist/')) return false;
+  return true;
+}
+
+function walk(dir, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    if (name === 'node_modules' || name === 'dist' || name === '.turbo') continue;
+    const full = join(dir, name);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      walk(full, out);
+    } else if (st.isFile() && isScanCandidate(full)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// Find every publishBoltEvent(...) call. Multi-line aware: the parser
+// scans forward from each `publishBoltEvent(` occurrence, picking off the
+// first and second comma-separated top-level arguments while respecting
+// string literals, template literals, and parenthesis depth.
+function extractCalls(content) {
+  const calls = [];
+  const needle = 'publishBoltEvent(';
+  let idx = 0;
+  while (true) {
+    const at = content.indexOf(needle, idx);
+    if (at === -1) break;
+    // Skip function *declarations* / *definitions* / imports / comments:
+    //   export async function publishBoltEvent(...
+    //   export declare function publishBoltEvent(...
+    //   import { publishBoltEvent } from ...
+    //   // publishBoltEvent: ...
+    const preSlice = content.slice(Math.max(0, at - 60), at);
+    if (/\bfunction\s+$/.test(preSlice)) {
+      idx = at + needle.length;
+      continue;
+    }
+    if (/\bimport\b[^;]*\{\s*$/.test(preSlice)) {
+      idx = at + needle.length;
+      continue;
+    }
+    // Skip if we're inside a line comment
+    const lineStart = content.lastIndexOf('\n', at) + 1;
+    const lineUpToCall = content.slice(lineStart, at);
+    if (lineUpToCall.includes('//')) {
+      idx = at + needle.length;
+      continue;
+    }
+    // Skip if inside a block comment. Rough heuristic: previous /* is
+    // unmatched by a */ before our position.
+    const lastOpen = content.lastIndexOf('/*', at);
+    const lastClose = content.lastIndexOf('*/', at);
+    if (lastOpen !== -1 && lastOpen > lastClose) {
+      idx = at + needle.length;
+      continue;
+    }
+
+    const argsStart = at + needle.length;
+    const parsed = parseCallArgs(content, argsStart);
+    if (parsed) {
+      const line = content.slice(0, at).split('\n').length;
+      calls.push({ line, firstArg: parsed.args[0], secondArg: parsed.args[1] });
+    }
+    idx = argsStart;
+  }
+  return calls;
+}
+
+// Parse args starting from the first char INSIDE the paren. Returns
+// { args: string[], endIndex } where each arg is the raw token text.
+// Only collects the first 2 args; beyond that we stop tracking because
+// this guard only cares about eventType and source.
+function parseCallArgs(src, start) {
+  const args = [];
+  let depth = 0; // paren depth (we start at depth 0 INSIDE the first paren)
+  let braceDepth = 0;
+  let bracketDepth = 0;
+  let stringChar = null; // `'` | `"` | `` ` ``
+  let templateDepth = 0; // nested ${...} counter
+  let curStart = start;
+  let i = start;
+
+  while (i < src.length) {
+    const c = src[i];
+    const prev = src[i - 1];
+
+    if (stringChar) {
+      if (c === '\\' && prev !== '\\') {
+        i += 2;
+        continue;
+      }
+      if (stringChar === '`' && c === '$' && src[i + 1] === '{') {
+        templateDepth++;
+        i += 2;
+        continue;
+      }
+      if (c === stringChar && prev !== '\\') {
+        stringChar = null;
+      }
+      i++;
+      continue;
+    }
+    if (templateDepth > 0 && c === '}') {
+      templateDepth--;
+      i++;
+      continue;
+    }
+    if (c === "'" || c === '"' || c === '`') {
+      stringChar = c;
+      i++;
+      continue;
+    }
+    if (c === '(') {
+      depth++;
+      i++;
+      continue;
+    }
+    if (c === ')') {
+      if (depth === 0 && braceDepth === 0 && bracketDepth === 0) {
+        // End of call.
+        const tok = src.slice(curStart, i).trim();
+        if (tok.length > 0 || args.length > 0) args.push(tok);
+        return { args, endIndex: i + 1 };
+      }
+      depth--;
+      i++;
+      continue;
+    }
+    if (c === '{') { braceDepth++; i++; continue; }
+    if (c === '}') { braceDepth--; i++; continue; }
+    if (c === '[') { bracketDepth++; i++; continue; }
+    if (c === ']') { bracketDepth--; i++; continue; }
+    if (c === ',' && depth === 0 && braceDepth === 0 && bracketDepth === 0) {
+      args.push(src.slice(curStart, i).trim());
+      curStart = i + 1;
+      if (args.length >= 2) {
+        // We already have eventType and source; scan forward to the
+        // matching close paren for completeness, but do not track more
+        // args. Short-circuit: just walk to the end.
+        // We still need to exit cleanly so the caller can move on.
+      }
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return null;
+}
+
+function unquote(tok) {
+  if (!tok) return null;
+  const m = tok.match(/^(['"`])(.*)\1$/s);
+  return m ? m[2] : null;
+}
+
+function main() {
+  const files = [];
+  for (const r of SCAN_ROOTS) {
+    walk(join(ROOT, r), files);
+  }
+
+  const violations = [];
+  let callsScanned = 0;
+
+  for (const file of files) {
+    let content;
+    try {
+      content = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    if (!content.includes('publishBoltEvent(')) continue;
+
+    const calls = extractCalls(content);
+    for (const call of calls) {
+      callsScanned++;
+      const rel = relative(ROOT, file).replace(/\\/g, '/');
+
+      // R1: first arg must be a string literal.
+      const firstLit = unquote(call.firstArg);
+      if (firstLit === null) {
+        violations.push({
+          file: rel,
+          line: call.line,
+          rule: 'R1-first-arg-literal',
+          msg: `publishBoltEvent first argument must be a string literal, got \`${call.firstArg ?? '<empty>'}\``,
+        });
+        continue;
+      }
+
+      // R2: event name must not be in the legacy prefixed deny-list.
+      if (PREFIXED_BAD_NAMES.has(firstLit)) {
+        violations.push({
+          file: rel,
+          line: call.line,
+          rule: 'R2-no-prefixed-event',
+          msg: `event name '${firstLit}' is a legacy prefixed name; strip the source prefix (see Cross_Product_Integration_Plan.md Step 4 / P0.3)`,
+        });
+      }
+
+      // R3: second arg must be a string literal in KNOWN_SOURCES.
+      const secondLit = unquote(call.secondArg);
+      if (secondLit === null) {
+        violations.push({
+          file: rel,
+          line: call.line,
+          rule: 'R3-source-literal',
+          msg: `publishBoltEvent second argument must be a string literal source, got \`${call.secondArg ?? '<missing>'}\``,
+        });
+      } else if (!KNOWN_SOURCES.has(secondLit)) {
+        violations.push({
+          file: rel,
+          line: call.line,
+          rule: 'R3-source-enum',
+          msg: `publishBoltEvent source '${secondLit}' is not in BoltEventSource union (packages/shared/src/bolt-events.ts)`,
+        });
+      }
+    }
+  }
+
+  console.log(`[check-bolt-catalog] scanned ${files.length} file(s), ${callsScanned} publishBoltEvent call(s)`);
+
+  if (violations.length === 0) {
+    console.log('[check-bolt-catalog] clean');
+    process.exit(0);
+  }
+
+  for (const v of violations) {
+    console.error(`${v.file}:${v.line}  [${v.rule}] ${v.msg}`);
+  }
+  console.error(`\n[check-bolt-catalog] ${violations.length} violation(s)`);
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Wave 0.4 of the 2026-04-13 push. Implements Step 4 (P0.3, Event Naming Convention Sweep) from [`docs/plans/2026-04-13-revised/Cross_Product_Integration_Plan.md`](../blob/feature-completion-wip/docs/plans/2026-04-13-revised/Cross_Product_Integration_Plan.md) lines 656-712.

Three logical changes:

1. **Rename `bond.deal.rotting` -> `deal.rotting`** in the one remaining emitter (`apps/worker/src/jobs/bond-stale-deals.job.ts`) and its unit test assertions. The source arg stays `'bond'` so the canonical `(eventType, source, payload, orgId, ...)` shape is unchanged; only the event type string becomes bare.
2. **Migration `0072_bolt_rename_prefixed_events.sql`** rewrites any historical row in `bolt_automations.trigger_event` (text) and `bolt_executions.trigger_event` (jsonb, via `jsonb_set` on the `_event_type` key) that still carries the legacy literal.
3. **New drift-guard script `scripts/check-bolt-catalog.mjs`** with three rules (R1 first arg must be a string literal; R2 first arg must not be in the `PREFIXED_BAD_NAMES` deny-list; R3 second arg must be a string literal in the `BoltEventSource` enum). Wired into `pnpm check:bolt-catalog`.

Branch targets `feature-completion-wip`, not `main`, per Wave 0 convention.

## Sweep results

### Grep sweep 1 (prefixed event names)

Plan's grep (`publishBoltEvent\(\s*['\"](bam|...|bond|...)\.`) with `grep -v test | grep -v '.md'`.

**Before (multiline-aware, `grep -rnzP` with UTF-8 locale):**

```
apps/worker/src/jobs/bond-stale-deals.job.ts:114
  publishBoltEvent(
    'bond.deal.rotting',
    ...
```

One match. The line-based grep the plan documents does NOT catch this one because the call spans multiple lines; use `grep -rnzP` (or the drift-guard script) to actually hit it.

**After rename:** zero matches. The drift-guard script reports `[check-bolt-catalog] clean` across 47 call sites in 915 scanned files. Smoke-tested by temporarily reverting the rename and confirming R2 fires with the expected message, then restoring.

### Grep sweep 2 (missing source arg)

Plan's grep (`publishBoltEvent\(\s*['\"][^'\"]+['\"],\s*[^'\"]`).

**Before and after:** the line-based grep as written has false-positive behavior against Windows grep (it produces matches on `brief-api/src/services/document.service.ts` for calls that clearly have a string literal source). The drift-guard script, which uses a hand-rolled top-level-comma-aware parser, finds zero violations of R3 (all 47 sites have a string literal source, all 47 sources are in the `BoltEventSource` enum).

## Migration 0072

Text shape follows the plan's template with one correction (flagged as D-011a in `DECISIONS.md`):

- `bolt_automations.trigger_event` is `varchar(60) NOT NULL` (`apps/bolt-api/src/db/schema/bolt-automations.ts:45`). The plan's `UPDATE ... SET trigger_event = 'deal.rotting' WHERE trigger_event = 'bond.deal.rotting'` works as-is.
- `bolt_executions.trigger_event` is `jsonb` (not text), storing the full payload `{ ...event.payload, _event_id, _source, _event_type }` per `apps/bolt-api/src/routes/event-ingestion.routes.ts`. Uses `jsonb_set(trigger_event, '{_event_type}', '"deal.rotting"'::jsonb, false)` with `WHERE trigger_event->>'_event_type' = 'bond.deal.rotting'` so NULL rows and rows missing the key are naturally skipped.

Both UPDATEs are idempotent. `pnpm lint:migrations` passes (0 violations, 18 pre-existing warnings on older migrations that are out of scope). Claimed in `MIGRATION_LEDGER.md`.

## Drift-guard script

`scripts/check-bolt-catalog.mjs` walks `apps/` and `packages/` for `.ts` files (excluding tests, `.d.ts`, `dist`, `node_modules`, and the shared implementation itself), finds every `publishBoltEvent(` call, and uses a small hand-rolled parser to extract the first two positional args in a way that survives multi-line calls, template literals, nested parens, and escape sequences.

The plan's original framing was "extend the existing `check:bolt-catalog` script from §2.1" but that script did not land during Waves 0.1 / 0.2 / 0.3 (no file, no npm script). I created it fresh with just the two P0.3 assertions; catalog presence remains the §2.1 owner's responsibility. See `DECISIONS.md` D-011b for the reasoning and D-011c for why R2 uses an exact-match deny-list instead of a source-prefix regex.

Smoke-tested both positive and negative cases:
- revert the rename -> `R2-no-prefixed-event` fires at `apps/worker/src/jobs/bond-stale-deals.job.ts:114`
- inject a call with a non-literal source -> `R3-source-literal` fires
- inject a call with source `'notasource'` -> `R3-source-enum` fires

## Worker test update

`apps/worker/test/bond-stale-deals.test.ts` had two `toHaveBeenNthCalledWith` blocks pinning the first arg to `'bond.deal.rotting'`; both are updated to `'deal.rotting'`. The describe-block title is also updated.

## Test plan

- [x] `pnpm lint:migrations` passes (0 violations, 18 pre-existing warnings).
- [x] `node scripts/check-bolt-catalog.mjs` passes (clean, 47 call sites scanned).
- [x] Smoke-tested all three drift-guard rules (R1, R2, R3) with temporary known-bad inputs.
- [ ] `pnpm --filter @bigbluebam/worker build` and `test` — could not run locally; cold `pnpm install --node-linker=hoisted --ignore-scripts` was still running when the PR opened (Windows host, pnpm linker is slow). Expected to pass because the change is a pure string literal rename and the test assertions were updated to match. CI will validate.
- [ ] `pnpm lint`, `pnpm -r typecheck`, `pnpm -r test` — deferred to CI for the same reason.

## Pre-existing issues surfaced (recorded, not fixed)

- **`bolt-api/src/services/event-catalog.ts` does not list `deal.rotting`.** The catalog has `deal.created`, `deal.updated`, `deal.stage_changed`, `deal.won`, `deal.lost` but no `deal.rotting`. This is a gap the plan's Step 5 (P0 event wiring / missing emitters) will own; it is out of scope for Wave 0.4. Any Bolt rule that wants to react to rotting deals today must match on `source: bond, event_type: deal.rotting` manually because the catalog lookup will miss.
- **`packages/shared/src/bolt-events.ts` has `schedule` in the `BoltEventSource` union** but no service is declared with that source anywhere in `apps/`. Left alone in this PR (touching the union would expand scope). Recorded here for the schedule-service owner.
- **Multi-line grep is the only sweep that actually worked.** The plan's grep pattern as documented in line 669 does not catch the `bond-stale-deals.job.ts` call because the call spans multiple lines and `grep` is line-based by default. The drift-guard script is what this PR adds to make the check reliable in CI; the plan text should get an update to recommend the script over the ad-hoc grep.

## Files changed

- `apps/worker/src/jobs/bond-stale-deals.job.ts` (rename + doc update)
- `apps/worker/test/bond-stale-deals.test.ts` (expected call shape)
- `CLAUDE.md` (refresh the Bond stale-deal bullet)
- `infra/postgres/migrations/0072_bolt_rename_prefixed_events.sql` (new)
- `scripts/check-bolt-catalog.mjs` (new)
- `package.json` (pnpm check:bolt-catalog script)
- `docs/plans/2026-04-13-revised/DECISIONS.md` (D-011a/b/c)
- `docs/plans/2026-04-13-revised/MIGRATION_LEDGER.md` (mark 0072 claimed)

## Commits

- `f340d1d` fix(worker): rename bond.deal.rotting to deal.rotting
- `9c6dc0d` feat(migrations): add 0072 to rewrite historical prefixed event names
- `77c510e` chore(scripts): add check-bolt-catalog drift guard for naming and signature

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>