### PR TITLE
Wave 1.C: Shared Zod schemas for 11 apps (P0.4)

### DIFF
--- a/packages/shared/src/schemas/banter.ts
+++ b/packages/shared/src/schemas/banter.ts
@@ -1,0 +1,224 @@
+import { z } from 'zod';
+
+// ── Enums ──────────────────────────────────────────────────────────────
+export const BanterChannelType = z.enum(['public', 'private', 'dm', 'group_dm']);
+export const BanterContentFormat = z.enum(['html', 'markdown', 'plain']);
+export const BanterNotificationLevel = z.enum(['all', 'mentions', 'none']);
+export const BanterSidebarSort = z.enum(['recent', 'alpha', 'custom']);
+export const BanterTimestampVisibility = z.enum(['hover', 'always', 'never']);
+export const BanterPresenceStatus = z.enum(['online', 'idle', 'dnd']);
+export const BanterCallType = z.enum(['voice', 'video', 'huddle']);
+export const BanterAiAgentMode = z.enum(['auto', 'on', 'off']);
+export const BanterChannelCreationPolicy = z.enum(['members', 'admins']);
+
+// ── Channel schemas ────────────────────────────────────────────────────
+export const createBanterChannelSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(80)
+    .regex(/^[a-z0-9][a-z0-9-]*$/, 'Must be lowercase alphanumeric with hyphens'),
+  type: z.enum(['public', 'private']).default('public'),
+  topic: z.string().max(500).optional(),
+  description: z.string().optional(),
+  channel_group_id: z.string().uuid().optional(),
+});
+
+export const updateBanterChannelSchema = z.object({
+  name: z.string().min(1).max(80).optional(),
+  display_name: z.string().max(100).nullable().optional(),
+  topic: z.string().max(500).nullable().optional(),
+  description: z.string().nullable().optional(),
+  icon: z.string().max(10).nullable().optional(),
+  channel_group_id: z.string().uuid().nullable().optional(),
+  allow_bots: z.boolean().optional(),
+  allow_huddles: z.boolean().optional(),
+  message_retention_days: z.number().int().min(0).nullable().optional(),
+});
+
+export const addBanterChannelMembersSchema = z.object({
+  user_ids: z.array(z.string().uuid()).min(1).max(100),
+});
+
+export const markBanterChannelReadSchema = z.object({
+  message_id: z.string().uuid(),
+});
+
+// ── Message schemas ────────────────────────────────────────────────────
+export const createBanterMessageSchema = z.object({
+  content: z.string().min(1).max(40000),
+  content_format: BanterContentFormat.default('html'),
+  thread_parent_id: z.string().uuid().optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export const updateBanterMessageSchema = z.object({
+  content: z.string().min(1).max(40000),
+});
+
+export const listBanterMessagesQuerySchema = z.object({
+  before: z.string().optional(),
+  after: z.string().optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+// ── Thread schemas ─────────────────────────────────────────────────────
+export const createBanterThreadReplySchema = z.object({
+  content: z.string().min(1).max(40000),
+  content_format: BanterContentFormat.default('html'),
+});
+
+// ── DM schemas ─────────────────────────────────────────────────────────
+export const createBanterDmSchema = z.object({
+  user_id: z.string().uuid(),
+});
+
+export const createBanterGroupDmSchema = z.object({
+  user_ids: z.array(z.string().uuid()).min(2).max(7),
+});
+
+// ── Reaction schemas ───────────────────────────────────────────────────
+export const toggleBanterReactionSchema = z.object({
+  emoji: z.string().min(1).max(50),
+});
+
+// ── Bookmark schemas ───────────────────────────────────────────────────
+export const createBanterBookmarkSchema = z.object({
+  message_id: z.string().uuid(),
+  note: z.string().max(500).optional(),
+});
+
+// ── Pin schemas ────────────────────────────────────────────────────────
+export const createBanterPinSchema = z.object({
+  message_id: z.string().uuid(),
+});
+
+// ── Preference schemas ─────────────────────────────────────────────────
+export const updateBanterPreferencesSchema = z.object({
+  default_notification_level: BanterNotificationLevel.optional(),
+  sidebar_sort: BanterSidebarSort.optional(),
+  sidebar_collapsed_groups: z.array(z.string().uuid()).optional(),
+  theme_override: z.string().max(20).nullable().optional(),
+  enter_sends_message: z.boolean().optional(),
+  show_message_timestamps: BanterTimestampVisibility.optional(),
+  compact_mode: z.boolean().optional(),
+  auto_join_huddles: z.boolean().optional(),
+  noise_suppression: z.boolean().optional(),
+});
+
+export const setBanterPresenceSchema = z.object({
+  status: BanterPresenceStatus,
+});
+
+// ── Call schemas ───────────────────────────────────────────────────────
+export const startBanterCallSchema = z.object({
+  type: BanterCallType,
+  title: z.string().max(255).optional(),
+  ai_agent_mode: BanterAiAgentMode.default('auto'),
+});
+
+export const listBanterCallHistoryQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+// ── User group schemas ─────────────────────────────────────────────────
+export const createBanterUserGroupSchema = z.object({
+  name: z.string().min(1).max(80),
+  handle: z
+    .string()
+    .min(1)
+    .max(80)
+    .regex(/^[a-z0-9][a-z0-9-]*$/, 'Must be lowercase alphanumeric with hyphens'),
+  description: z.string().max(500).optional(),
+});
+
+export const updateBanterUserGroupSchema = z.object({
+  name: z.string().min(1).max(80).optional(),
+  handle: z
+    .string()
+    .min(1)
+    .max(80)
+    .regex(/^[a-z0-9][a-z0-9-]*$/, 'Must be lowercase alphanumeric with hyphens')
+    .optional(),
+  description: z.string().max(500).nullable().optional(),
+});
+
+export const addBanterUserGroupMembersSchema = z.object({
+  user_ids: z.array(z.string().uuid()).min(1).max(100),
+});
+
+// ── Channel group / admin schemas ──────────────────────────────────────
+export const createBanterChannelGroupSchema = z.object({
+  name: z.string().min(1).max(100),
+  position: z.number().int().min(0).optional(),
+  is_collapsed_default: z.boolean().optional(),
+});
+
+export const updateBanterChannelGroupSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  position: z.number().int().min(0).optional(),
+  is_collapsed_default: z.boolean().optional(),
+});
+
+export const reorderBanterChannelGroupsSchema = z.object({
+  order: z.array(
+    z.object({
+      id: z.string().uuid(),
+      position: z.number().int().min(0),
+    }),
+  ),
+});
+
+export const updateBanterSettingsSchema = z.object({
+  allow_channel_creation: BanterChannelCreationPolicy.optional(),
+  allow_dm: z.boolean().optional(),
+  allow_group_dm: z.boolean().optional(),
+  allow_guest_access: z.boolean().optional(),
+  message_retention_days: z.number().int().min(0).optional(),
+  max_file_size_mb: z.number().int().min(1).optional(),
+  allowed_file_types: z.array(z.string()).optional(),
+  enable_link_previews: z.boolean().optional(),
+  enable_bbb_integration: z.boolean().optional(),
+  voice_video_enabled: z.boolean().optional(),
+  livekit_host: z.string().max(500).nullable().optional(),
+  livekit_api_key: z.string().max(255).nullable().optional(),
+  livekit_api_secret: z.string().nullable().optional(),
+  max_call_participants: z.number().int().min(2).max(500).optional(),
+  max_call_duration_minutes: z.number().int().min(1).optional(),
+});
+
+// ── Search schemas ─────────────────────────────────────────────────────
+export const searchBanterMessagesQuerySchema = z.object({
+  q: z.string().min(1).max(500),
+  channel_id: z.string().uuid().optional(),
+  author_id: z.string().uuid().optional(),
+  before: z.string().datetime().optional(),
+  after: z.string().datetime().optional(),
+  has_attachments: z
+    .enum(['true', 'false'])
+    .transform((v) => v === 'true')
+    .optional(),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export const searchBanterTranscriptsQuerySchema = z.object({
+  q: z.string().min(1).max(500),
+  channel_id: z.string().uuid().optional(),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export const searchBanterChannelsQuerySchema = z.object({
+  q: z.string().min(1).max(200),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+// ── User resolver schemas ──────────────────────────────────────────────
+export const listBanterUsersQuerySchema = z.object({
+  q: z.string().trim().min(1).max(200).optional(),
+  limit: z.coerce.number().int().min(1).max(20).default(20),
+});

--- a/packages/shared/src/schemas/beacon.ts
+++ b/packages/shared/src/schemas/beacon.ts
@@ -1,0 +1,139 @@
+import { z } from 'zod';
+
+// ── Enums ──────────────────────────────────────────────────────────────
+export const BeaconVisibility = z.enum(['Public', 'Organization', 'Project', 'Private']);
+export const BeaconLinkType = z.enum([
+  'RelatedTo',
+  'Supersedes',
+  'DependsOn',
+  'ConflictsWith',
+  'SeeAlso',
+]);
+export const BeaconPolicyScope = z.enum(['System', 'Organization', 'Project']);
+export const BeaconSavedQueryScope = z.enum(['Private', 'Project', 'Organization']);
+export const BeaconGraphScope = z.enum(['project', 'organization']);
+
+// ── Beacon (document) schemas ──────────────────────────────────────────
+export const createBeaconSchema = z.object({
+  title: z.string().min(1).max(512),
+  summary: z.string().max(500).nullable().optional(),
+  body_markdown: z.string().min(1).max(500_000),
+  body_html: z.string().nullable().optional(),
+  visibility: BeaconVisibility.optional(),
+  project_id: z.string().uuid().nullable().optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export const updateBeaconSchema = z.object({
+  title: z.string().min(1).max(512).optional(),
+  summary: z.string().max(500).nullable().optional(),
+  body_markdown: z.string().min(1).max(500_000).optional(),
+  body_html: z.string().nullable().optional(),
+  visibility: BeaconVisibility.optional(),
+  metadata: z.record(z.unknown()).optional(),
+  change_note: z.string().max(500).optional(),
+});
+
+export const listBeaconsQuerySchema = z.object({
+  project_ids: z.string().optional(), // comma-separated UUIDs
+  project_id: z.string().uuid().optional(),
+  status: z.string().optional(),
+  tag: z.string().optional(),
+  tags: z.string().optional(), // comma-separated
+  visibility_max: z.string().optional(),
+  expires_after: z.string().optional(),
+  search: z.string().optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(1000).optional(),
+});
+
+// ── Link schemas ───────────────────────────────────────────────────────
+export const createBeaconLinkSchema = z.object({
+  target_id: z.string().uuid(),
+  link_type: BeaconLinkType,
+});
+
+// ── Tag schemas ────────────────────────────────────────────────────────
+export const addBeaconTagsSchema = z.object({
+  tags: z.array(z.string().min(1).max(128)).min(1).max(20),
+});
+
+// ── Policy schemas ─────────────────────────────────────────────────────
+export const setBeaconPolicySchema = z.object({
+  scope: BeaconPolicyScope,
+  organization_id: z.string().uuid().optional(),
+  project_id: z.string().uuid().optional(),
+  min_expiry_days: z.number().int().min(1),
+  max_expiry_days: z.number().int().min(1),
+  default_expiry_days: z.number().int().min(1),
+  grace_period_days: z.number().int().min(1),
+});
+
+export const resolveBeaconPolicyQuerySchema = z.object({
+  project_id: z.string().uuid().optional(),
+});
+
+// ── Search schemas ─────────────────────────────────────────────────────
+export const searchBeaconsRequestSchema = z.object({
+  query: z.string().max(1000),
+  filters: z
+    .object({
+      organization_id: z.string().uuid().optional(),
+      project_ids: z.array(z.string().uuid()).optional(),
+      status: z.array(z.string()).optional(),
+      tags: z.array(z.string()).optional(),
+      visibility_max: BeaconVisibility.optional(),
+      expires_after: z.string().optional(),
+    })
+    .optional(),
+  options: z
+    .object({
+      include_graph_expansion: z.boolean().optional(),
+      include_tag_expansion: z.boolean().optional(),
+      include_fulltext_fallback: z.boolean().optional(),
+      rerank: z.boolean().optional(),
+      top_k: z.number().int().min(0).max(100).optional(),
+      group_by_beacon: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+export const suggestBeaconsQuerySchema = z.object({
+  q: z.string().min(1).max(200),
+  limit: z.coerce.number().int().min(1).max(50).optional(),
+});
+
+export const saveBeaconQuerySchema = z.object({
+  name: z.string().min(1).max(200),
+  description: z.string().max(500).nullable().optional(),
+  query_body: z.record(z.unknown()),
+  scope: BeaconSavedQueryScope.optional(),
+  project_id: z.string().uuid().nullable().optional(),
+});
+
+// ── Graph schemas ──────────────────────────────────────────────────────
+export const beaconGraphNeighborsQuerySchema = z.object({
+  beacon_id: z.string().uuid(),
+  hops: z.coerce.number().int().min(1).max(3).default(1),
+  include_implicit: z
+    .enum(['true', 'false'])
+    .default('true')
+    .transform((v) => v === 'true'),
+  tag_affinity_threshold: z.coerce.number().int().min(1).max(5).default(2),
+  'filters.status': z
+    .union([z.string(), z.array(z.string())])
+    .default(['Active', 'PendingReview'])
+    .transform((v) => (Array.isArray(v) ? v : [v])),
+});
+
+export const beaconGraphHubsQuerySchema = z.object({
+  scope: BeaconGraphScope.default('project'),
+  project_id: z.string().uuid().optional(),
+  top_k: z.coerce.number().int().min(1).max(50).default(20),
+});
+
+export const beaconGraphRecentQuerySchema = z.object({
+  scope: BeaconGraphScope.default('project'),
+  project_id: z.string().uuid().optional(),
+  days: z.coerce.number().int().min(1).max(90).default(7),
+});

--- a/packages/shared/src/schemas/bench.ts
+++ b/packages/shared/src/schemas/bench.ts
@@ -1,0 +1,178 @@
+import { z } from 'zod';
+
+// ── Enums ──────────────────────────────────────────────────────────────
+export const BenchDashboardVisibility = z.enum(['private', 'project', 'organization']);
+export const BenchWidgetType = z.enum([
+  'bar_chart',
+  'line_chart',
+  'area_chart',
+  'pie_chart',
+  'donut_chart',
+  'scatter_plot',
+  'heatmap',
+  'funnel',
+  'table',
+  'pivot_table',
+  'kpi_card',
+  'counter',
+  'gauge',
+  'progress_bar',
+  'text',
+  'markdown',
+]);
+export const BenchMeasureAgg = z.enum(['count', 'sum', 'avg', 'min', 'max']);
+export const BenchFilterOp = z.enum([
+  'eq',
+  'neq',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'in',
+  'is_null',
+  'is_not_null',
+  'between',
+  'like',
+]);
+export const BenchTimeGranularity = z.enum([
+  'hour',
+  'day',
+  'week',
+  'month',
+  'quarter',
+  'year',
+]);
+export const BenchSortDir = z.enum(['asc', 'desc']);
+export const BenchReportDeliveryMethod = z.enum([
+  'email',
+  'banter_channel',
+  'brief_document',
+]);
+export const BenchReportExportFormat = z.enum(['pdf', 'png', 'csv']);
+
+// ── Query config building blocks ───────────────────────────────────────
+export const benchQueryMeasureSchema = z.object({
+  field: z.string().min(1).max(100),
+  agg: BenchMeasureAgg,
+  alias: z.string().max(100).optional(),
+});
+
+export const benchQueryDimensionSchema = z.object({
+  field: z.string().min(1).max(100),
+  alias: z.string().max(100).optional(),
+});
+
+export const benchQueryFilterSchema = z.object({
+  field: z.string().min(1).max(100),
+  op: BenchFilterOp,
+  value: z.unknown(),
+});
+
+export const benchQuerySortSchema = z.object({
+  field: z.string(),
+  dir: BenchSortDir,
+});
+
+export const benchQueryConfigSchema = z.object({
+  measures: z.array(benchQueryMeasureSchema).min(1),
+  dimensions: z.array(benchQueryDimensionSchema).optional(),
+  filters: z.array(benchQueryFilterSchema).optional(),
+  sort: z.array(benchQuerySortSchema).optional(),
+  limit: z.number().int().positive().max(10000).optional(),
+  time_dimension: z
+    .object({
+      field: z.string(),
+      granularity: BenchTimeGranularity,
+    })
+    .optional(),
+  date_range: z
+    .object({
+      preset: z.string().optional(),
+      start: z.string().optional(),
+      end: z.string().optional(),
+    })
+    .optional(),
+});
+
+// ── Dashboard schemas ──────────────────────────────────────────────────
+export const createBenchDashboardSchema = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(2000).optional(),
+  project_id: z.string().uuid().optional(),
+  visibility: BenchDashboardVisibility.optional(),
+  is_default: z.boolean().optional(),
+  auto_refresh_seconds: z.number().int().positive().optional(),
+  layout: z.array(z.record(z.unknown())).optional(),
+});
+
+export const updateBenchDashboardSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().max(2000).optional(),
+  project_id: z.string().uuid().nullable().optional(),
+  visibility: BenchDashboardVisibility.optional(),
+  is_default: z.boolean().optional(),
+  auto_refresh_seconds: z.number().int().positive().nullable().optional(),
+  layout: z.array(z.record(z.unknown())).optional(),
+});
+
+export const listBenchDashboardsQuerySchema = z.object({
+  project_id: z.string().uuid().optional(),
+  visibility: BenchDashboardVisibility.optional(),
+  search: z.string().max(200).optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  sort: z.string().optional(),
+});
+
+// ── Widget schemas ─────────────────────────────────────────────────────
+export const createBenchWidgetSchema = z.object({
+  name: z.string().min(1).max(255),
+  widget_type: BenchWidgetType,
+  data_source: z.string().min(1).max(30),
+  entity: z.string().min(1).max(60),
+  query_config: benchQueryConfigSchema,
+  viz_config: z.record(z.unknown()).optional(),
+  kpi_config: z.record(z.unknown()).optional(),
+  cache_ttl_seconds: z.number().int().positive().optional(),
+});
+
+export const updateBenchWidgetSchema = createBenchWidgetSchema.partial();
+
+export const listBenchWidgetsQuerySchema = z.object({
+  dashboard_id: z.string().uuid().optional(),
+});
+
+// ── Data source preview ───────────────────────────────────────────────
+export const previewBenchDataSourceQuerySchema = z.object({
+  data_source: z.string().min(1).max(30),
+  entity: z.string().min(1).max(60),
+  query_config: benchQueryConfigSchema,
+});
+
+// ── Report schemas ─────────────────────────────────────────────────────
+export const createBenchReportSchema = z.object({
+  dashboard_id: z.string().uuid(),
+  name: z.string().min(1).max(255),
+  cron_expression: z.string().min(1).max(100),
+  cron_timezone: z.string().max(50).optional(),
+  delivery_method: BenchReportDeliveryMethod,
+  delivery_target: z.string().min(1),
+  export_format: BenchReportExportFormat.optional(),
+  enabled: z.boolean().optional(),
+});
+
+export const updateBenchReportSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  cron_expression: z.string().min(1).max(100).optional(),
+  cron_timezone: z.string().max(50).optional(),
+  delivery_method: BenchReportDeliveryMethod.optional(),
+  delivery_target: z.string().min(1).optional(),
+  export_format: BenchReportExportFormat.optional(),
+  enabled: z.boolean().optional(),
+});
+
+export const listBenchReportsQuerySchema = z.object({
+  search: z.string().max(200).optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});

--- a/packages/shared/src/schemas/bill.ts
+++ b/packages/shared/src/schemas/bill.ts
@@ -1,0 +1,169 @@
+import { z } from 'zod';
+
+// ── Enums ──────────────────────────────────────────────────────────────
+export const BillPaymentMethod = z.enum([
+  'bank_transfer',
+  'credit_card',
+  'check',
+  'cash',
+  'stripe',
+  'paypal',
+  'other',
+]);
+export const BillRateType = z.enum(['hourly', 'daily', 'fixed']);
+
+// ── Client schemas ─────────────────────────────────────────────────────
+export const createBillClientSchema = z.object({
+  name: z.string().min(1).max(255),
+  email: z.string().email().max(255).optional(),
+  phone: z.string().max(50).optional(),
+  address_line1: z.string().max(255).optional(),
+  address_line2: z.string().max(255).optional(),
+  city: z.string().max(100).optional(),
+  state_region: z.string().max(100).optional(),
+  postal_code: z.string().max(20).optional(),
+  country: z.string().length(2).optional(),
+  tax_id: z.string().max(50).optional(),
+  bond_company_id: z.string().uuid().optional(),
+  default_payment_terms_days: z.number().int().min(0).max(365).optional(),
+  default_payment_instructions: z.string().max(2000).optional(),
+  notes: z.string().max(5000).optional(),
+});
+
+export const updateBillClientSchema = createBillClientSchema.partial();
+
+export const listBillClientsQuerySchema = z.object({
+  search: z.string().max(200).optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  sort: z.string().optional(),
+});
+
+// ── Invoice schemas ────────────────────────────────────────────────────
+export const createBillInvoiceSchema = z.object({
+  client_id: z.string().uuid(),
+  project_id: z.string().uuid().optional(),
+  invoice_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  due_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  tax_rate: z.number().min(0).max(100).optional(),
+  discount_amount: z.number().int().min(0).optional(),
+  payment_terms_days: z.number().int().min(0).max(365).optional(),
+  payment_instructions: z.string().max(2000).optional(),
+  notes: z.string().max(5000).optional(),
+  footer_text: z.string().max(2000).optional(),
+  terms_text: z.string().max(5000).optional(),
+  bond_deal_id: z.string().uuid().optional(),
+});
+
+export const updateBillInvoiceSchema = createBillInvoiceSchema.partial();
+
+export const listBillInvoicesQuerySchema = z.object({
+  status: z.string().optional(),
+  client_id: z.string().uuid().optional(),
+  project_id: z.string().uuid().optional(),
+  date_from: z.string().optional(),
+  date_to: z.string().optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  sort: z.string().optional(),
+});
+
+export const createBillInvoiceLineItemSchema = z.object({
+  description: z.string().min(1).max(1000),
+  quantity: z.number().positive().optional(),
+  unit: z.string().max(20).optional(),
+  unit_price: z.number().int().min(0),
+  sort_order: z.number().int().optional(),
+  time_entry_ids: z.array(z.string().uuid()).optional(),
+  task_id: z.string().uuid().optional(),
+});
+
+export const updateBillInvoiceLineItemSchema = z.object({
+  description: z.string().min(1).max(1000).optional(),
+  quantity: z.number().positive().optional(),
+  unit: z.string().max(20).optional(),
+  unit_price: z.number().int().min(0).optional(),
+  sort_order: z.number().int().optional(),
+});
+
+// ── Expense schemas ────────────────────────────────────────────────────
+export const createBillExpenseSchema = z.object({
+  project_id: z.string().uuid().optional(),
+  description: z.string().min(1).max(1000),
+  amount: z.number().int().positive(),
+  currency: z.string().length(3).optional(),
+  category: z.string().max(60).optional(),
+  vendor: z.string().max(255).optional(),
+  expense_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  receipt_url: z.string().url().optional(),
+  receipt_filename: z.string().max(255).optional(),
+  billable: z.boolean().optional(),
+});
+
+export const updateBillExpenseSchema = createBillExpenseSchema.partial();
+
+export const listBillExpensesQuerySchema = z.object({
+  project_id: z.string().uuid().optional(),
+  category: z.string().optional(),
+  status: z.string().optional(),
+  date_from: z.string().optional(),
+  date_to: z.string().optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  sort: z.string().optional(),
+});
+
+// ── Payment schemas ────────────────────────────────────────────────────
+export const recordBillPaymentSchema = z.object({
+  amount: z.number().int().positive(),
+  payment_method: BillPaymentMethod.optional(),
+  reference: z.string().max(255).optional(),
+  notes: z.string().max(2000).optional(),
+  paid_at: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+});
+
+// ── Rate schemas ───────────────────────────────────────────────────────
+export const createBillRateSchema = z.object({
+  project_id: z.string().uuid().optional(),
+  user_id: z.string().uuid().optional(),
+  rate_amount: z.number().int().positive(),
+  rate_type: BillRateType.optional(),
+  currency: z.string().length(3).optional(),
+  effective_from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  effective_to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+});
+
+export const updateBillRateSchema = z.object({
+  rate_amount: z.number().int().positive().optional(),
+  rate_type: BillRateType.optional(),
+  effective_from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  effective_to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+});
+
+export const listBillRatesQuerySchema = z.object({
+  project_id: z.string().uuid().optional(),
+  user_id: z.string().uuid().optional(),
+});
+
+export const resolveBillRateQuerySchema = z.object({
+  project_id: z.string().uuid().optional(),
+  user_id: z.string().uuid().optional(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+});
+
+// ── Settings schemas ───────────────────────────────────────────────────
+export const updateBillSettingsSchema = z.object({
+  company_name: z.string().max(255).optional(),
+  company_email: z.string().email().max(255).optional(),
+  company_phone: z.string().max(50).optional(),
+  company_address: z.string().max(2000).optional(),
+  company_logo_url: z.string().url().optional(),
+  company_tax_id: z.string().max(50).optional(),
+  default_currency: z.string().length(3).optional(),
+  default_tax_rate: z.number().min(0).max(100).optional(),
+  default_payment_terms_days: z.number().int().min(0).max(365).optional(),
+  default_payment_instructions: z.string().max(2000).optional(),
+  default_footer_text: z.string().max(2000).optional(),
+  default_terms_text: z.string().max(5000).optional(),
+  invoice_prefix: z.string().min(1).max(20).optional(),
+});

--- a/packages/shared/src/schemas/blank.ts
+++ b/packages/shared/src/schemas/blank.ts
@@ -1,0 +1,194 @@
+import { z } from 'zod';
+
+// ── Enums ──────────────────────────────────────────────────────────────
+export const BlankFieldType = z.enum([
+  'short_text',
+  'long_text',
+  'email',
+  'phone',
+  'url',
+  'number',
+  'single_select',
+  'multi_select',
+  'dropdown',
+  'date',
+  'time',
+  'datetime',
+  'file_upload',
+  'image_upload',
+  'rating',
+  'scale',
+  'nps',
+  'checkbox',
+  'toggle',
+  'section_header',
+  'paragraph',
+  'hidden',
+]);
+export const BlankFormType = z.enum(['public', 'internal', 'embedded']);
+export const BlankFormVisibility = z.enum(['public', 'org', 'project']);
+export const BlankConfirmationType = z.enum(['message', 'redirect', 'page']);
+export const BlankConditionalOp = z.enum([
+  'equals',
+  'not_equals',
+  'contains',
+  'gt',
+  'lt',
+  'is_set',
+  'is_not_set',
+]);
+
+// ── Field schemas ──────────────────────────────────────────────────────
+export const createBlankFieldSchema = z.object({
+  field_key: z
+    .string()
+    .min(1)
+    .max(60)
+    .regex(
+      /^[a-zA-Z_][a-zA-Z0-9_]*$/,
+      'field_key must be a safe identifier (letters, digits, underscores; must start with letter or underscore)',
+    ),
+  label: z.string().min(1).max(500),
+  description: z.string().max(2000).optional(),
+  placeholder: z.string().max(255).optional(),
+  field_type: BlankFieldType,
+  required: z.boolean().optional(),
+  min_length: z.number().int().positive().optional(),
+  max_length: z.number().int().positive().optional(),
+  options: z.unknown().optional(),
+  scale_min: z.number().int().optional(),
+  scale_max: z.number().int().optional(),
+  scale_min_label: z.string().max(100).optional(),
+  scale_max_label: z.string().max(100).optional(),
+  allowed_file_types: z.array(z.string()).optional(),
+  max_file_size_mb: z.number().int().positive().optional(),
+  conditional_on_field_id: z.string().uuid().optional(),
+  conditional_operator: BlankConditionalOp.optional(),
+  conditional_value: z.string().optional(),
+  sort_order: z.number().int().optional(),
+  page_number: z.number().int().positive().optional(),
+  column_span: z.number().int().min(1).max(2).optional(),
+  default_value: z.string().optional(),
+});
+
+export const updateBlankFieldSchema = z.object({
+  label: z.string().min(1).max(500).optional(),
+  description: z.string().max(2000).nullable().optional(),
+  placeholder: z.string().max(255).nullable().optional(),
+  field_type: BlankFieldType.optional(),
+  required: z.boolean().optional(),
+  min_length: z.number().int().positive().nullable().optional(),
+  max_length: z.number().int().positive().nullable().optional(),
+  options: z.unknown().optional(),
+  scale_min: z.number().int().optional(),
+  scale_max: z.number().int().optional(),
+  scale_min_label: z.string().max(100).nullable().optional(),
+  scale_max_label: z.string().max(100).nullable().optional(),
+  sort_order: z.number().int().optional(),
+  page_number: z.number().int().positive().optional(),
+  column_span: z.number().int().min(1).max(2).optional(),
+  default_value: z.string().nullable().optional(),
+});
+
+export const reorderBlankFieldsSchema = z.object({
+  fields: z.array(
+    z.object({
+      id: z.string().uuid(),
+      sort_order: z.number().int(),
+    }),
+  ),
+});
+
+// ── Form schemas ───────────────────────────────────────────────────────
+export const blankFormFieldInputSchema = z.object({
+  field_key: z
+    .string()
+    .min(1)
+    .max(60)
+    .regex(/^[a-zA-Z_][a-zA-Z0-9_]*$/, 'field_key must be a safe identifier'),
+  label: z.string().min(1).max(500),
+  description: z.string().max(2000).optional(),
+  placeholder: z.string().max(255).optional(),
+  field_type: BlankFieldType,
+  required: z.boolean().optional(),
+  min_length: z.number().int().positive().optional(),
+  max_length: z.number().int().positive().optional(),
+  options: z.unknown().optional(),
+  scale_min: z.number().int().optional(),
+  scale_max: z.number().int().optional(),
+  scale_min_label: z.string().max(100).optional(),
+  scale_max_label: z.string().max(100).optional(),
+  sort_order: z.number().int().optional(),
+  page_number: z.number().int().positive().optional(),
+  column_span: z.number().int().min(1).max(2).optional(),
+  default_value: z.string().optional(),
+});
+
+export const createBlankFormSchema = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(5000).optional(),
+  slug: z
+    .string()
+    .min(1)
+    .max(60)
+    .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/),
+  project_id: z.string().uuid().optional(),
+  form_type: BlankFormType.optional(),
+  visibility: BlankFormVisibility.optional(),
+  expires_at: z.string().datetime().nullable().optional(),
+  requires_login: z.boolean().optional(),
+  confirmation_type: BlankConfirmationType.optional(),
+  confirmation_message: z.string().max(5000).optional(),
+  confirmation_redirect_url: z.string().url().optional(),
+  theme_color: z.string().max(7).optional(),
+  fields: z.array(blankFormFieldInputSchema).optional(),
+});
+
+export const updateBlankFormSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().max(5000).nullable().optional(),
+  slug: z
+    .string()
+    .min(1)
+    .max(60)
+    .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/)
+    .optional(),
+  project_id: z.string().uuid().nullable().optional(),
+  form_type: BlankFormType.optional(),
+  visibility: BlankFormVisibility.optional(),
+  expires_at: z.string().datetime().nullable().optional(),
+  requires_login: z.boolean().optional(),
+  accept_responses: z.boolean().optional(),
+  max_responses: z.number().int().positive().nullable().optional(),
+  one_per_email: z.boolean().optional(),
+  show_progress_bar: z.boolean().optional(),
+  shuffle_fields: z.boolean().optional(),
+  confirmation_type: BlankConfirmationType.optional(),
+  confirmation_message: z.string().max(5000).optional(),
+  confirmation_redirect_url: z.string().url().nullable().optional(),
+  header_image_url: z.string().url().nullable().optional(),
+  theme_color: z.string().max(7).optional(),
+});
+
+export const listBlankFormsQuerySchema = z.object({
+  project_id: z.string().uuid().optional(),
+  visibility: BlankFormVisibility.optional(),
+  search: z.string().max(200).optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  sort: z.string().optional(),
+});
+
+// ── Submission schemas ─────────────────────────────────────────────────
+export const submitBlankFormSchema = z.object({
+  response_data: z.record(z.unknown()),
+  email: z.string().email().optional(),
+  captcha_token: z.string().optional(),
+});
+
+export const listBlankSubmissionsQuerySchema = z.object({
+  form_id: z.string().uuid().optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  sort: z.string().optional(),
+});

--- a/packages/shared/src/schemas/blast.ts
+++ b/packages/shared/src/schemas/blast.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod';
+
+// ── Enums ──────────────────────────────────────────────────────────────
+export const BlastTemplateType = z.enum([
+  'campaign',
+  'drip_step',
+  'transactional',
+  'system',
+]);
+export const BlastAnalyticsTrendPeriod = z.enum(['daily', 'weekly', 'monthly']);
+export const BlastBounceType = z.enum(['hard', 'soft', 'complaint']);
+export const BlastSegmentMatch = z.enum(['all', 'any']);
+
+// ── Campaign schemas ───────────────────────────────────────────────────
+export const createBlastCampaignSchema = z.object({
+  name: z.string().min(1).max(255),
+  template_id: z.string().uuid().optional(),
+  subject: z.string().min(1).max(500),
+  html_body: z.string().min(1),
+  plain_text_body: z.string().optional(),
+  segment_id: z.string().uuid().optional(),
+  from_name: z
+    .string()
+    .max(100)
+    .regex(/^[^\r\n]*$/, 'from_name must not contain line breaks')
+    .optional(),
+  from_email: z.string().email().max(255).optional(),
+  reply_to_email: z.string().email().max(255).optional(),
+});
+
+export const updateBlastCampaignSchema = createBlastCampaignSchema.partial();
+
+export const scheduleBlastCampaignSchema = z.object({
+  scheduled_at: z.string().datetime(),
+});
+
+export const listBlastCampaignsQuerySchema = z.object({
+  status: z.string().optional(),
+  search: z.string().max(200).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+  cursor: z.string().optional(),
+  sort: z.string().optional(),
+});
+
+export const listBlastRecipientsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+});
+
+// ── Template schemas ───────────────────────────────────────────────────
+export const createBlastTemplateSchema = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(2000).optional(),
+  subject_template: z.string().min(1).max(500),
+  html_body: z.string().min(1),
+  json_design: z.unknown().optional(),
+  plain_text_body: z.string().optional(),
+  template_type: BlastTemplateType.optional(),
+  thumbnail_url: z.string().url().optional(),
+});
+
+export const updateBlastTemplateSchema = createBlastTemplateSchema.partial();
+
+export const listBlastTemplatesQuerySchema = z.object({
+  template_type: z.string().optional(),
+  search: z.string().max(200).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+  cursor: z.string().optional(),
+  sort: z.string().optional(),
+});
+
+// ── Segment schemas ────────────────────────────────────────────────────
+export const blastSegmentConditionSchema = z.object({
+  field: z.string().min(1),
+  op: z.string().min(1),
+  value: z.unknown(),
+});
+
+export const createBlastSegmentSchema = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(2000).optional(),
+  filter_criteria: z.object({
+    conditions: z.array(blastSegmentConditionSchema).min(1).max(20),
+    match: BlastSegmentMatch,
+  }),
+});
+
+export const updateBlastSegmentSchema = createBlastSegmentSchema.partial();
+
+export const listBlastSegmentsQuerySchema = z.object({
+  search: z.string().max(200).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+  cursor: z.string().optional(),
+  sort: z.string().optional(),
+});
+
+// ── Sender domain schemas ──────────────────────────────────────────────
+export const addBlastSenderDomainSchema = z.object({
+  domain: z
+    .string()
+    .min(3)
+    .max(255)
+    .regex(
+      /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i,
+      'Invalid domain format',
+    ),
+});
+
+// ── Analytics schemas ──────────────────────────────────────────────────
+export const blastAnalyticsTrendQuerySchema = z.object({
+  period: BlastAnalyticsTrendPeriod.optional(),
+});
+
+export const blastUnsubCheckQuerySchema = z.object({
+  email: z.string().email(),
+});
+
+// ── Webhook schemas ────────────────────────────────────────────────────
+export const blastBounceWebhookSchema = z.object({
+  message_id: z.string().optional(),
+  email: z.string().email().optional(),
+  bounce_type: BlastBounceType,
+  reason: z.string().optional(),
+});
+
+export const blastComplaintWebhookSchema = z.object({
+  message_id: z.string().optional(),
+  email: z.string().email().optional(),
+});

--- a/packages/shared/src/schemas/board.ts
+++ b/packages/shared/src/schemas/board.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod';
+
+// ── Enums ──────────────────────────────────────────────────────────────
+export const BoardBackground = z.enum(['dots', 'grid', 'lines', 'plain']);
+export const BoardVisibility = z.enum(['private', 'project', 'organization']);
+export const BoardCollaboratorPermission = z.enum(['view', 'edit']);
+export const BoardElementExportFormat = z.enum(['json', 'svg', 'png']);
+
+// ── Board schemas ──────────────────────────────────────────────────────
+export const createBoardSchema = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(2000).nullable().optional(),
+  icon: z.string().max(10).nullable().optional(),
+  project_id: z.string().uuid().nullable().optional(),
+  template_id: z.string().uuid().nullable().optional(),
+  background: BoardBackground.optional().default('dots'),
+  visibility: BoardVisibility.optional().default('project'),
+  default_viewport: z.record(z.unknown()).nullable().optional(),
+});
+
+export const updateBoardSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().max(2000).nullable().optional(),
+  icon: z.string().max(10).nullable().optional(),
+  project_id: z.string().uuid().nullable().optional(),
+  background: BoardBackground.optional(),
+  visibility: BoardVisibility.optional(),
+  default_viewport: z.record(z.unknown()).nullable().optional(),
+  thumbnail_url: z.string().max(2048).nullable().optional(),
+});
+
+export const listBoardsQuerySchema = z.object({
+  project_id: z.string().uuid().optional(),
+  visibility: BoardVisibility.optional(),
+  created_by: z.string().uuid().optional(),
+  archived: z.enum(['true', 'false']).optional(),
+  search: z.string().max(500).optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+export const searchBoardsQuerySchema = z.object({
+  q: z.string().min(1).max(500),
+});
+
+// ── Element schemas ────────────────────────────────────────────────────
+export const createBoardStickySchema = z.object({
+  text: z.string().min(1).max(5000),
+  x: z.number().default(100),
+  y: z.number().default(100),
+  width: z.number().min(10).max(2000).default(200),
+  height: z.number().min(10).max(2000).default(200),
+  color: z.string().max(30).default('#FFEB3B'),
+});
+
+export const createBoardTextSchema = z.object({
+  text: z.string().min(1).max(10000),
+  x: z.number().default(100),
+  y: z.number().default(100),
+  font_size: z.number().min(8).max(200).default(20),
+  color: z.string().max(30).default('#000000'),
+});
+
+export const exportBoardElementsQuerySchema = z.object({
+  format: BoardElementExportFormat.default('json'),
+});
+
+// ── Scene schemas ──────────────────────────────────────────────────────
+export const saveBoardSceneSchema = z.object({
+  elements: z.array(z.unknown()),
+  appState: z.record(z.unknown()).optional(),
+  files: z.record(z.unknown()).optional(),
+});
+
+// ── Chat schemas ───────────────────────────────────────────────────────
+export const sendBoardChatMessageSchema = z.object({
+  body: z.string().min(1).max(5000),
+});
+
+// ── Collaborator schemas ───────────────────────────────────────────────
+export const addBoardCollaboratorSchema = z.object({
+  user_id: z.string().uuid(),
+  permission: BoardCollaboratorPermission.optional().default('edit'),
+});
+
+export const updateBoardCollaboratorSchema = z.object({
+  permission: BoardCollaboratorPermission,
+});
+
+// ── Link / promote schemas ─────────────────────────────────────────────
+export const promoteBoardElementsSchema = z.object({
+  element_ids: z.array(z.string().uuid()).min(1).max(100),
+  project_id: z.string().uuid(),
+  phase_id: z.string().uuid().optional(),
+});
+
+// ── Template schemas ───────────────────────────────────────────────────
+export const createBoardTemplateSchema = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(2000).nullable().optional(),
+  category: z.string().max(100).nullable().optional(),
+  icon: z.string().max(10).nullable().optional(),
+  board_id: z.string().uuid().optional(),
+});
+
+export const updateBoardTemplateSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().max(2000).nullable().optional(),
+  category: z.string().max(100).nullable().optional(),
+  icon: z.string().max(10).nullable().optional(),
+  sort_order: z.number().int().min(0).max(10000).optional(),
+});
+
+export const instantiateBoardTemplateSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  project_id: z.string().uuid().optional(),
+});
+
+export const listBoardTemplatesQuerySchema = z.object({
+  category: z.string().max(100).optional(),
+});
+
+// ── Version schemas ────────────────────────────────────────────────────
+export const createBoardVersionSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+});

--- a/packages/shared/src/schemas/bolt.ts
+++ b/packages/shared/src/schemas/bolt.ts
@@ -1,0 +1,193 @@
+import { z } from 'zod';
+
+// NOTE: The Bolt node-graph authoring model lives in
+// `packages/shared/src/bolt-graph.ts` and `bolt-graph-shape.ts`. Those files
+// define the structural/graph types used by the compiler and the React Flow
+// editor. This schema file covers the HTTP-facing CRUD surface of the Bolt
+// REST API: automations, executions, templates, AI assist, and the
+// /v1/events/ingest body shape.
+
+// ── Enums ──────────────────────────────────────────────────────────────
+export const BoltTriggerSource = z.enum([
+  'bam',
+  'banter',
+  'beacon',
+  'brief',
+  'helpdesk',
+  'schedule',
+  'bond',
+  'blast',
+  'board',
+  'bench',
+  'bearing',
+  'bill',
+  'book',
+  'blank',
+]);
+
+export const BoltConditionOperator = z.enum([
+  'equals',
+  'not_equals',
+  'contains',
+  'not_contains',
+  'starts_with',
+  'ends_with',
+  'greater_than',
+  'less_than',
+  'is_empty',
+  'is_not_empty',
+  'in',
+  'not_in',
+  'matches_regex',
+]);
+
+export const BoltLogicGroup = z.enum(['and', 'or']);
+export const BoltNodeKindSchema = z.enum(['trigger', 'condition', 'action']);
+export const BoltActorTypeSchema = z.enum(['user', 'agent', 'system']);
+
+// ── Graph (thin wire schema, full types in bolt-graph.ts) ──────────────
+export const boltGraphNodeWireSchema = z.object({
+  id: z.string().min(1),
+  kind: BoltNodeKindSchema,
+  position: z.object({ x: z.number(), y: z.number() }),
+  data: z.record(z.unknown()),
+});
+
+export const boltGraphEdgeWireSchema = z.object({
+  id: z.string().min(1),
+  source: z.string().min(1),
+  sourceHandle: z.string().min(1),
+  target: z.string().min(1),
+  targetHandle: z.string().min(1),
+});
+
+export const boltGraphWireSchema = z.object({
+  version: z.literal(1),
+  nodes: z.array(boltGraphNodeWireSchema),
+  edges: z.array(boltGraphEdgeWireSchema),
+});
+
+// ── Automation condition/action rows ───────────────────────────────────
+export const boltAutomationConditionSchema = z.object({
+  sort_order: z.number().int().min(0).max(100),
+  field: z.string().min(1).max(255),
+  operator: BoltConditionOperator,
+  value: z.unknown().optional(),
+  logic_group: BoltLogicGroup.optional().default('and'),
+});
+
+export const boltAutomationActionSchema = z.object({
+  sort_order: z.number().int().min(0).max(100),
+  mcp_tool: z.string().min(1).max(100),
+  parameters: z.record(z.unknown()).optional(),
+});
+
+// ── Automation schemas ─────────────────────────────────────────────────
+export const createBoltAutomationSchema = z
+  .object({
+    name: z.string().min(1).max(255),
+    description: z.string().max(5000).nullable().optional(),
+    project_id: z.string().uuid().nullable().optional(),
+    enabled: z.boolean().optional().default(true),
+    trigger_source: BoltTriggerSource,
+    trigger_event: z.string().min(1).max(60),
+    trigger_filter: z.record(z.unknown()).nullable().optional(),
+    cron_expression: z.string().max(100).nullable().optional(),
+    cron_timezone: z.string().max(50).optional().default('UTC'),
+    max_executions_per_hour: z.number().int().min(1).max(10000).optional().default(100),
+    cooldown_seconds: z.number().int().min(0).max(86400).optional().default(0),
+    conditions: z.array(boltAutomationConditionSchema).max(50).optional().default([]),
+    actions: z.array(boltAutomationActionSchema).min(1).max(50).optional(),
+    graph: boltGraphWireSchema.optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.graph && (!data.actions || data.actions.length === 0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Automation must provide either a graph or at least one action',
+        path: ['actions'],
+      });
+    }
+  });
+
+export const updateBoltAutomationSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().max(5000).nullable().optional(),
+  project_id: z.string().uuid().nullable().optional(),
+  enabled: z.boolean().optional(),
+  trigger_source: BoltTriggerSource.optional(),
+  trigger_event: z.string().min(1).max(60).optional(),
+  trigger_filter: z.record(z.unknown()).nullable().optional(),
+  cron_expression: z.string().max(100).nullable().optional(),
+  cron_timezone: z.string().max(50).optional(),
+  max_executions_per_hour: z.number().int().min(1).max(10000).optional(),
+  cooldown_seconds: z.number().int().min(0).max(86400).optional(),
+  conditions: z.array(boltAutomationConditionSchema).max(50).optional(),
+  actions: z.array(boltAutomationActionSchema).min(1).max(50).optional(),
+  graph: boltGraphWireSchema.optional(),
+});
+
+export const patchBoltAutomationSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().max(5000).nullable().optional(),
+  enabled: z.boolean().optional(),
+});
+
+export const listBoltAutomationsQuerySchema = z.object({
+  project_id: z.string().uuid().optional(),
+  trigger_source: z.string().optional(),
+  enabled: z.enum(['true', 'false']).optional(),
+  search: z.string().max(500).optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+export const testBoltAutomationSchema = z.object({
+  event: z.record(z.unknown()),
+});
+
+// ── Execution schemas ──────────────────────────────────────────────────
+export const listBoltExecutionsQuerySchema = z.object({
+  status: z.string().optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+// ── Template schemas ───────────────────────────────────────────────────
+export const instantiateBoltTemplateSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().max(5000).nullable().optional(),
+  project_id: z.string().uuid().nullable().optional(),
+  cron_expression: z.string().max(100).nullable().optional(),
+  cron_timezone: z.string().max(50).optional(),
+});
+
+// ── Event ingest schemas ───────────────────────────────────────────────
+export const boltEventIngestSchema = z.object({
+  event_type: z.string().min(1).max(60),
+  source: BoltTriggerSource,
+  payload: z.record(z.unknown()),
+  org_id: z.string().uuid(),
+  project_id: z.string().uuid().optional(),
+  actor_id: z.string().uuid().optional(),
+  actor_type: BoltActorTypeSchema.optional(),
+  chain_depth: z.number().int().min(0).max(100).optional().default(0),
+});
+
+// ── AI assist schemas ──────────────────────────────────────────────────
+export const boltAiGenerateSchema = z.object({
+  prompt: z.string().min(1).max(2000),
+  context: z.record(z.unknown()).optional(),
+  project_id: z.string().uuid().optional(),
+});
+
+export const boltAiExplainSchema = z.object({
+  automation: z.object({
+    name: z.string().max(255),
+    trigger_source: z.string().max(30),
+    trigger_event: z.string().max(60),
+    conditions: z.array(z.record(z.unknown())).optional().default([]),
+    actions: z.array(z.record(z.unknown())).optional().default([]),
+  }),
+  project_id: z.string().uuid().optional(),
+});

--- a/packages/shared/src/schemas/bond.ts
+++ b/packages/shared/src/schemas/bond.ts
@@ -1,0 +1,348 @@
+import { z } from 'zod';
+
+// ── Enums ──────────────────────────────────────────────────────────────
+export const BondLifecycleStage = z.enum([
+  'subscriber',
+  'lead',
+  'marketing_qualified',
+  'sales_qualified',
+  'opportunity',
+  'customer',
+  'evangelist',
+  'other',
+]);
+
+export const BondCompanySize = z.enum([
+  '1-10',
+  '11-50',
+  '51-200',
+  '201-1000',
+  '1001-5000',
+  '5000+',
+]);
+
+export const BondActivityType = z.enum([
+  'note',
+  'email_sent',
+  'email_received',
+  'call',
+  'meeting',
+  'task',
+  'stage_change',
+  'deal_created',
+  'deal_won',
+  'deal_lost',
+  'contact_created',
+  'form_submission',
+  'campaign_sent',
+  'campaign_opened',
+  'campaign_clicked',
+  'custom',
+]);
+
+export const BondCustomFieldEntityType = z.enum(['contact', 'company', 'deal']);
+export const BondCustomFieldType = z.enum([
+  'text',
+  'number',
+  'date',
+  'select',
+  'multi_select',
+  'url',
+  'email',
+  'phone',
+  'boolean',
+]);
+export const BondStageType = z.enum(['active', 'won', 'lost']);
+export const BondScoringConditionOperator = z.enum([
+  'equals',
+  'not_equals',
+  'contains',
+  'gt',
+  'lt',
+  'gte',
+  'lte',
+  'exists',
+  'not_exists',
+]);
+
+// ── Contact schemas ────────────────────────────────────────────────────
+export const createBondContactSchema = z.object({
+  first_name: z.string().max(100).optional(),
+  last_name: z.string().max(100).optional(),
+  email: z.string().email().max(255).optional(),
+  phone: z.string().max(50).optional(),
+  title: z.string().max(150).optional(),
+  avatar_url: z.string().url().optional(),
+  lifecycle_stage: BondLifecycleStage.optional(),
+  lead_source: z.string().max(60).optional(),
+  address_line1: z.string().max(255).optional(),
+  address_line2: z.string().max(255).optional(),
+  city: z.string().max(100).optional(),
+  state_region: z.string().max(100).optional(),
+  postal_code: z.string().max(20).optional(),
+  country: z.string().length(2).optional(),
+  custom_fields: z.record(z.unknown()).optional(),
+  owner_id: z.string().uuid().optional(),
+});
+
+export const updateBondContactSchema = createBondContactSchema.partial();
+
+export const mergeBondContactSchema = z.object({
+  source_id: z.string().uuid(),
+});
+
+export const importBondContactsSchema = z.object({
+  contacts: z.array(createBondContactSchema).min(1).max(5000),
+});
+
+export const listBondContactsQuerySchema = z.object({
+  lifecycle_stage: z.string().optional(),
+  lead_source: z.string().optional(),
+  owner_id: z.string().uuid().optional(),
+  company_id: z.string().uuid().optional(),
+  lead_score_min: z.coerce.number().int().optional(),
+  lead_score_max: z.coerce.number().int().optional(),
+  search: z.string().max(200).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+  cursor: z.string().optional(),
+  sort: z.string().optional(),
+});
+
+export const searchBondContactsQuerySchema = z.object({
+  q: z.string().min(1).max(200),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+// ── Company schemas ────────────────────────────────────────────────────
+export const createBondCompanySchema = z.object({
+  name: z.string().min(1).max(255),
+  domain: z.string().max(255).optional(),
+  industry: z.string().max(100).optional(),
+  size_bucket: BondCompanySize.optional(),
+  annual_revenue: z.number().int().optional(),
+  phone: z.string().max(50).optional(),
+  website: z.string().url().optional(),
+  logo_url: z.string().url().optional(),
+  address_line1: z.string().max(255).optional(),
+  address_line2: z.string().max(255).optional(),
+  city: z.string().max(100).optional(),
+  state_region: z.string().max(100).optional(),
+  postal_code: z.string().max(20).optional(),
+  country: z.string().length(2).optional(),
+  custom_fields: z.record(z.unknown()).optional(),
+  owner_id: z.string().uuid().optional(),
+});
+
+export const updateBondCompanySchema = createBondCompanySchema.partial();
+
+export const listBondCompaniesQuerySchema = z.object({
+  industry: z.string().optional(),
+  size_bucket: z.string().optional(),
+  owner_id: z.string().uuid().optional(),
+  search: z.string().max(200).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+  cursor: z.string().optional(),
+  sort: z.string().optional(),
+});
+
+export const searchBondCompaniesQuerySchema = z.object({
+  q: z.string().min(1).max(200),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+// ── Deal schemas ───────────────────────────────────────────────────────
+export const createBondDealSchema = z.object({
+  name: z.string().min(1).max(255),
+  pipeline_id: z.string().uuid(),
+  stage_id: z.string().uuid(),
+  description: z.string().max(5000).optional(),
+  value: z.number().int().min(0).optional(),
+  currency: z.string().length(3).optional(),
+  expected_close_date: z.string().optional(),
+  probability_pct: z.number().int().min(0).max(100).optional(),
+  owner_id: z.string().uuid().optional(),
+  company_id: z.string().uuid().optional(),
+  custom_fields: z.record(z.unknown()).optional(),
+});
+
+export const updateBondDealSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().max(5000).optional(),
+  value: z.number().int().min(0).optional(),
+  currency: z.string().length(3).optional(),
+  expected_close_date: z.string().optional(),
+  probability_pct: z.number().int().min(0).max(100).optional(),
+  owner_id: z.string().uuid().optional(),
+  company_id: z.string().uuid().nullable().optional(),
+  custom_fields: z.record(z.unknown()).optional(),
+});
+
+export const moveBondDealStageSchema = z.object({
+  stage_id: z.string().uuid(),
+});
+
+export const closeBondDealWonSchema = z.object({
+  close_reason: z.string().max(2000).optional(),
+});
+
+export const closeBondDealLostSchema = z.object({
+  close_reason: z.string().max(2000).optional(),
+  lost_to_competitor: z.string().max(255).optional(),
+});
+
+export const addBondDealContactSchema = z.object({
+  contact_id: z.string().uuid(),
+  role: z.string().max(60).optional(),
+});
+
+export const listBondDealsQuerySchema = z.object({
+  pipeline_id: z.string().uuid().optional(),
+  stage_id: z.string().uuid().optional(),
+  owner_id: z.string().uuid().optional(),
+  company_id: z.string().uuid().optional(),
+  value_min: z.coerce.number().int().optional(),
+  value_max: z.coerce.number().int().optional(),
+  expected_close_after: z.string().optional(),
+  expected_close_before: z.string().optional(),
+  stale: z.coerce.boolean().optional(),
+  search: z.string().max(200).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+  cursor: z.string().optional(),
+  sort: z.string().optional(),
+});
+
+// ── Pipeline schemas ───────────────────────────────────────────────────
+export const createBondStageSchema = z.object({
+  name: z.string().min(1).max(100),
+  sort_order: z.number().int().optional(),
+  stage_type: BondStageType.optional(),
+  probability_pct: z.number().int().min(0).max(100).optional(),
+  rotting_days: z.number().int().positive().optional(),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+});
+
+export const updateBondStageSchema = createBondStageSchema.partial();
+
+export const createBondPipelineSchema = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(2000).optional(),
+  is_default: z.boolean().optional(),
+  currency: z.string().length(3).optional(),
+  stages: z.array(createBondStageSchema).optional(),
+});
+
+export const updateBondPipelineSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().max(2000).optional(),
+  is_default: z.boolean().optional(),
+  currency: z.string().length(3).optional(),
+});
+
+export const reorderBondStagesSchema = z.object({
+  stage_ids: z.array(z.string().uuid()).min(1),
+});
+
+// ── Activity schemas ───────────────────────────────────────────────────
+export const createBondActivitySchema = z.object({
+  contact_id: z.string().uuid().optional(),
+  deal_id: z.string().uuid().optional(),
+  company_id: z.string().uuid().optional(),
+  activity_type: BondActivityType,
+  subject: z.string().max(255).optional(),
+  body: z.string().max(10000).optional(),
+  metadata: z.record(z.unknown()).optional(),
+  performed_at: z.string().datetime().optional(),
+});
+
+export const updateBondActivitySchema = z.object({
+  subject: z.string().max(255).optional(),
+  body: z.string().max(10000).optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export const listBondActivitiesQuerySchema = z.object({
+  contact_id: z.string().uuid().optional(),
+  deal_id: z.string().uuid().optional(),
+  company_id: z.string().uuid().optional(),
+  activity_type: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+  cursor: z.string().optional(),
+  sort: z.string().optional(),
+});
+
+// ── Custom field schemas ───────────────────────────────────────────────
+export const bondCustomFieldOptionSchema = z.object({
+  value: z.string().min(1).max(100),
+  label: z.string().min(1).max(100),
+});
+
+export const createBondCustomFieldSchema = z.object({
+  entity_type: BondCustomFieldEntityType,
+  field_key: z
+    .string()
+    .min(1)
+    .max(60)
+    .regex(/^[a-z][a-z0-9_]*$/, {
+      message:
+        'Field key must be lowercase alphanumeric with underscores, starting with a letter',
+    }),
+  label: z.string().min(1).max(100),
+  field_type: BondCustomFieldType,
+  options: z.array(bondCustomFieldOptionSchema).optional(),
+  required: z.boolean().optional(),
+  sort_order: z.number().int().min(0).optional(),
+});
+
+export const updateBondCustomFieldSchema = z.object({
+  label: z.string().min(1).max(100).optional(),
+  field_type: BondCustomFieldType.optional(),
+  options: z.array(bondCustomFieldOptionSchema).optional(),
+  required: z.boolean().optional(),
+  sort_order: z.number().int().min(0).optional(),
+});
+
+export const listBondCustomFieldsQuerySchema = z.object({
+  entity_type: BondCustomFieldEntityType.optional(),
+});
+
+// ── Scoring schemas ────────────────────────────────────────────────────
+export const createBondScoringRuleSchema = z.object({
+  name: z.string().min(1).max(100),
+  description: z.string().max(500).optional(),
+  condition_field: z.string().min(1).max(100),
+  condition_operator: BondScoringConditionOperator,
+  condition_value: z.string().max(500),
+  score_delta: z.number().int().min(-100).max(100),
+  enabled: z.boolean().optional(),
+});
+
+export const updateBondScoringRuleSchema = createBondScoringRuleSchema.partial();
+
+export const scoreBondContactSchema = z.object({
+  contact_id: z.string().uuid(),
+});
+
+// ── Analytics query schemas ────────────────────────────────────────────
+export const bondPipelineAnalyticsQuerySchema = z.object({
+  pipeline_id: z.string().uuid().optional(),
+});
+
+export const bondConversionAnalyticsQuerySchema = z.object({
+  pipeline_id: z.string().uuid(),
+  start_date: z.string().optional(),
+  end_date: z.string().optional(),
+});
+
+export const bondVelocityAnalyticsQuerySchema = z.object({
+  pipeline_id: z.string().uuid(),
+});
+
+export const bondWinLossAnalyticsQuerySchema = z.object({
+  pipeline_id: z.string().uuid().optional(),
+  start_date: z.string().optional(),
+  end_date: z.string().optional(),
+});

--- a/packages/shared/src/schemas/book.ts
+++ b/packages/shared/src/schemas/book.ts
@@ -1,0 +1,169 @@
+import { z } from 'zod';
+
+// ── Enums ──────────────────────────────────────────────────────────────
+export const BookCalendarType = z.enum(['personal', 'team', 'project', 'booking']);
+export const BookEventStatus = z.enum(['tentative', 'confirmed', 'cancelled']);
+export const BookEventVisibility = z.enum(['free', 'busy', 'tentative', 'out_of_office']);
+export const BookRecurrenceRule = z.enum(['daily', 'weekly', 'biweekly', 'monthly']);
+export const BookLinkedEntityType = z.enum([
+  'bam_task',
+  'bond_deal',
+  'helpdesk_ticket',
+]);
+export const BookRsvpResponse = z.enum(['accepted', 'declined', 'tentative']);
+export const BookSyncDirection = z.enum(['inbound', 'outbound', 'both']);
+
+// ── Calendar schemas ───────────────────────────────────────────────────
+export const createBookCalendarSchema = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(2000).optional(),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+  calendar_type: BookCalendarType.optional(),
+  timezone: z.string().max(50).optional(),
+  project_id: z.string().uuid().optional(),
+});
+
+export const updateBookCalendarSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().max(2000).optional(),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+  timezone: z.string().max(50).optional(),
+});
+
+export const listBookCalendarsQuerySchema = z.object({
+  calendar_type: z.string().optional(),
+});
+
+// ── Event schemas ──────────────────────────────────────────────────────
+export const createBookEventSchema = z.object({
+  calendar_id: z.string().uuid(),
+  title: z.string().min(1).max(500),
+  description: z.string().max(5000).optional(),
+  location: z.string().max(500).optional(),
+  meeting_url: z.string().url().optional(),
+  start_at: z.string().datetime(),
+  end_at: z.string().datetime(),
+  all_day: z.boolean().optional(),
+  timezone: z.string().max(50).optional(),
+  recurrence_rule: BookRecurrenceRule.optional(),
+  recurrence_end_at: z.string().datetime().optional(),
+  status: BookEventStatus.optional(),
+  visibility: BookEventVisibility.optional(),
+  linked_entity_type: BookLinkedEntityType.optional(),
+  linked_entity_id: z.string().uuid().optional(),
+});
+
+export const updateBookEventSchema = z.object({
+  title: z.string().min(1).max(500).optional(),
+  description: z.string().max(5000).optional(),
+  location: z.string().max(500).optional(),
+  meeting_url: z.string().url().nullable().optional(),
+  start_at: z.string().datetime().optional(),
+  end_at: z.string().datetime().optional(),
+  all_day: z.boolean().optional(),
+  timezone: z.string().max(50).optional(),
+  status: BookEventStatus.optional(),
+  visibility: BookEventVisibility.optional(),
+});
+
+export const rsvpBookEventSchema = z.object({
+  response_status: BookRsvpResponse,
+});
+
+export const listBookEventsQuerySchema = z.object({
+  calendar_ids: z.string().optional(), // comma-separated UUIDs
+  start_after: z.string().datetime().optional(),
+  start_before: z.string().datetime().optional(),
+  status: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(500).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+  cursor: z.string().optional(),
+  sort: z.string().optional(),
+});
+
+// ── Availability schemas ───────────────────────────────────────────────
+export const bookAvailabilityQuerySchema = z.object({
+  start_date: z.string().datetime(),
+  end_date: z.string().datetime(),
+});
+
+export const bookTeamAvailabilityQuerySchema = z.object({
+  user_ids: z.string(), // comma-separated UUIDs
+  start_date: z.string().datetime(),
+  end_date: z.string().datetime(),
+});
+
+export const bookWorkingHoursSchema = z.array(
+  z.object({
+    day_of_week: z.number().int().min(0).max(6),
+    start_time: z.string().regex(/^\d{2}:\d{2}(:\d{2})?$/),
+    end_time: z.string().regex(/^\d{2}:\d{2}(:\d{2})?$/),
+    timezone: z.string().max(50).optional(),
+    enabled: z.boolean().optional(),
+  }),
+);
+
+// ── Booking page schemas ───────────────────────────────────────────────
+export const createBookBookingPageSchema = z.object({
+  slug: z
+    .string()
+    .min(1)
+    .max(60)
+    .regex(/^[a-z0-9-]+$/),
+  title: z.string().min(1).max(255),
+  description: z.string().max(2000).optional(),
+  duration_minutes: z.number().int().min(5).max(480).optional(),
+  buffer_before_min: z.number().int().min(0).max(60).optional(),
+  buffer_after_min: z.number().int().min(0).max(60).optional(),
+  max_advance_days: z.number().int().min(1).max(365).optional(),
+  min_notice_hours: z.number().int().min(0).max(168).optional(),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+  logo_url: z.string().url().optional(),
+  confirmation_message: z.string().max(2000).optional(),
+  redirect_url: z.string().url().optional(),
+  auto_create_bond_contact: z.boolean().optional(),
+  auto_create_bam_task: z.boolean().optional(),
+  bam_project_id: z.string().uuid().optional(),
+});
+
+export const updateBookBookingPageSchema = createBookBookingPageSchema.partial();
+
+export const listBookBookingPagesQuerySchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  sort: z.string().optional(),
+});
+
+// ── Public booking schemas ─────────────────────────────────────────────
+export const bookPublicSlotsQuerySchema = z.object({
+  start_date: z.string(),
+  end_date: z.string(),
+});
+
+export const bookPublicBookSchema = z.object({
+  start_at: z.string().datetime(),
+  name: z.string().min(1).max(200),
+  email: z.string().email().max(255),
+  notes: z.string().max(2000).optional(),
+});
+
+// ── Timeline schemas ───────────────────────────────────────────────────
+export const bookTimelineQuerySchema = z.object({
+  start_date: z.string().datetime(),
+  end_date: z.string().datetime(),
+});
+
+// ── Connection schemas ─────────────────────────────────────────────────
+export const connectBookGoogleSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string().optional(),
+  external_calendar_id: z.string(),
+  sync_direction: BookSyncDirection.optional(),
+});
+
+export const connectBookMicrosoftSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string().optional(),
+  external_calendar_id: z.string(),
+  sync_direction: BookSyncDirection.optional(),
+});

--- a/packages/shared/src/schemas/helpdesk.ts
+++ b/packages/shared/src/schemas/helpdesk.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+
+// ── Enums ──────────────────────────────────────────────────────────────
+export const HelpdeskTicketStatus = z.enum([
+  'open',
+  'in_progress',
+  'waiting_on_customer',
+  'resolved',
+  'closed',
+]);
+export const HelpdeskTicketPriority = z.enum(['low', 'medium', 'high', 'critical']);
+export const HelpdeskSettingsPriority = z.enum(['low', 'medium', 'high', 'critical']);
+
+// ── Ticket schemas (customer-facing portal) ────────────────────────────
+export const createHelpdeskTicketSchema = z.object({
+  subject: z.string().min(1).max(500),
+  description: z.string().min(1),
+  category: z.string().max(100).optional(),
+  priority: z.enum(['low', 'medium', 'high']).default('medium'),
+  idempotency_key: z.string().max(200).optional(),
+});
+
+export const createHelpdeskCustomerMessageSchema = z.object({
+  body: z.string().min(1),
+});
+
+export const listHelpdeskTicketsQuerySchema = z.object({
+  status: z.string().optional(),
+  priority: z.string().optional(),
+  category: z.string().optional(),
+  search: z.string().max(200).optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  sort: z.string().optional(),
+});
+
+// ── Ticket schemas (agent side) ────────────────────────────────────────
+export const updateHelpdeskTicketSchema = z.object({
+  status: HelpdeskTicketStatus.optional(),
+  priority: HelpdeskTicketPriority.optional(),
+  category: z.string().max(100).optional(),
+});
+
+export const createHelpdeskAgentMessageSchema = z.object({
+  body: z.string().min(1),
+  is_internal: z.boolean().default(false),
+  author_name: z.string().min(1).max(100).optional(),
+  author_id: z.string().uuid().optional(),
+});
+
+// ── Auth schemas ───────────────────────────────────────────────────────
+export const registerHelpdeskUserSchema = z.object({
+  email: z.string().email().max(320),
+  display_name: z.string().min(1).max(100),
+  password: z.string().min(12).max(256),
+});
+
+export const loginHelpdeskUserSchema = z.object({
+  email: z.string().email(),
+  password: z.string(),
+});
+
+export const verifyHelpdeskEmailSchema = z.object({
+  token: z.string().min(1),
+});
+
+// ── Settings schemas ───────────────────────────────────────────────────
+export const updateHelpdeskSettingsSchema = z.object({
+  require_email_verification: z.boolean().optional(),
+  allowed_email_domains: z.array(z.string()).optional(),
+  default_project_id: z.string().uuid().nullable().optional(),
+  default_phase_id: z.string().uuid().nullable().optional(),
+  default_priority: HelpdeskSettingsPriority.optional(),
+  categories: z.array(z.string()).optional(),
+  welcome_message: z.string().nullable().optional(),
+  auto_close_days: z.number().int().min(0).optional(),
+  notify_on_status_change: z.boolean().optional(),
+  notify_on_agent_reply: z.boolean().optional(),
+});

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -9,3 +9,8 @@ export * from './comment.js';
 export * from './superuser.js';
 export * from './bearing.js';
 export * from './brief.js';
+export * from './banter.js';
+export * from './beacon.js';
+export * from './bench.js';
+export * from './bill.js';
+export * from './blank.js';

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -17,3 +17,6 @@ export * from './blank.js';
 export * from './blast.js';
 export * from './board.js';
 export * from './bolt.js';
+export * from './bond.js';
+export * from './book.js';
+export * from './helpdesk.js';

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -14,3 +14,6 @@ export * from './beacon.js';
 export * from './bench.js';
 export * from './bill.js';
 export * from './blank.js';
+export * from './blast.js';
+export * from './board.js';
+export * from './bolt.js';


### PR DESCRIPTION
## Summary

Wave 1 item 1.C of the 2026-04-13 push. Lifts inline Zod schemas from
the 11 apps that previously had no representation in
`packages/shared/src/schemas/` into the shared package so Wave 2 per-app
plans can migrate each app to import from a single source of truth.

Refs: **Platform_Plan.md §3.17** (lines 832-855) and
**Cross_Product_Integration_Plan.md §4 Step 6** (P0.4, lines 887-925).

## Coverage

11 new schema files, derived from the current inline Zod in each
app's `apps/<product>-api/src/routes/*.ts`. Each file exposes the
product's entity Create, Update, and List/query schemas plus the
enums they use.

- `packages/shared/src/schemas/banter.ts` (channels, messages, threads,
  DMs, reactions, bookmarks, pins, preferences, calls, user groups,
  channel groups, admin settings, search, user resolver)
- `packages/shared/src/schemas/beacon.ts` (beacons, links, tags,
  policies, search, graph neighbors/hubs/recent)
- `packages/shared/src/schemas/bench.ts` (dashboards, widgets, reports,
  data-source preview; query measure/dimension/filter building blocks)
- `packages/shared/src/schemas/bill.ts` (clients, invoices, invoice line
  items, expenses, payments, rates, settings)
- `packages/shared/src/schemas/blank.ts` (forms, fields, submissions,
  public submit; field type and conditional op enums)
- `packages/shared/src/schemas/blast.ts` (campaigns, templates, segments,
  sender domains, analytics queries, bounce/complaint webhook bodies)
- `packages/shared/src/schemas/board.ts` (boards, stickies, text
  elements, scene, chat, collaborators, template instantiation,
  versions, element promote)
- `packages/shared/src/schemas/bolt.ts` (automations, executions,
  templates, test, event ingest, AI generate/explain; thin graph wire
  schema)
- `packages/shared/src/schemas/bond.ts` (contacts, companies, deals,
  pipelines, stages, activities, custom fields, scoring rules,
  analytics query shapes)
- `packages/shared/src/schemas/book.ts` (calendars, events, availability,
  working hours, booking pages, public slots/book, timeline,
  external connections)
- `packages/shared/src/schemas/helpdesk.ts` (tickets, messages, auth
  register/login/verify, settings)

`packages/shared/src/schemas/index.ts` re-exports each new file.
Existing exports are not reordered or reformatted (append-only).

## Out of scope

Consumer migration is intentionally deferred. Per-app routes keep their
inline Zod bodies for this PR. Wave 2 per-app plans will switch each
app to import from `@bigbluebam/shared`.

## Divergences and notes

- **Bolt**: `packages/shared/src/bolt-graph.ts` and
  `bolt-graph-shape.ts` already define the BoltGraph authoring model
  (TS types and shape check). The new `schemas/bolt.ts` intentionally
  covers only the REST CRUD surface (automations, executions,
  templates, event ingest, AI assist) and does **not** duplicate the
  graph internals. A thin `boltGraphWireSchema` is re-stated in
  Zod form because the automation Create/Update bodies embed it and
  the existing types are TS-only.
- **Naming collisions avoided**: `BoltNodeKindSchema` and
  `BoltActorTypeSchema` carry the `Schema` suffix because the
  un-suffixed names `BoltNodeKind` and `BoltActorType` are already
  exported as TS types from `bolt-graph.ts` and `bolt-events.ts`
  respectively. All other enum exports use their natural names.
- **Banter**: uses the `Banter*` prefix to disambiguate from Bam's
  existing `createChannelSchema`/`createMessageSchema` if any.
- **Helpdesk auth**: ticket/auth/settings schemas are included even
  though helpdesk is a thin product; they match the existing
  `apps/helpdesk-api/src/routes/*.routes.ts` bodies.

## Verification

Local environment on Windows had persistent `pnpm install` failures
unrelated to this work (biome/tsup `.ignored_*` rename collisions on
Windows FS). A hoisted-linker install was sufficient to bring
`typescript` into place and run `tsc --noEmit` on `packages/shared`:

- `tsc --noEmit` on `packages/shared/src/` is clean after fixing two
  real conflicts in `bolt.ts` (`BoltNodeKind`/`BoltActorType` naming)
  uncovered during typecheck.

**Pre-existing tsc errors (not from this PR, not fixed):** two errors
in `packages/shared/src/bolt-events.ts` line 77 and 79 where
`res: Response` is missing `.ok` and `.status` properties. These are
tsconfig typing issues around Node fetch globals, unrelated to Wave
1.C. Flagging per CLAUDE.md "pre-existing is not a dismissal" rule so
a follow-up can address the `lib`/`types` setup on the shared
package. Not fixed in this PR because the fix is either (a) add `DOM`
to the shared tsconfig's `lib`, or (b) ensure `@types/node` node
version is resolved through `types`, both of which touch root
tsconfig and should be evaluated separately.

Local build verification via `tsup` was blocked by rollup optional-dep
loading (`@rollup/rollup-win32-x64-msvc`) which is a Windows pnpm
install artifact. CI on Linux should build cleanly.

## Test plan

- [x] `tsc --noEmit` on `packages/shared` is clean (post bolt.ts rename)
- [ ] CI lint + typecheck + unit tests pass
- [ ] Existing `packages/shared/test/schemas.test.ts` continues to pass
      (imports unchanged from this work)
- [ ] No runtime regressions in Wave 2 when apps migrate

🤖 Generated with [Claude Code](https://claude.com/claude-code)