### PR TITLE
ci(mcp): wire check-tool-return-coverage.mjs into db-drift workflow

### DIFF
--- a/.github/workflows/db-drift.yml
+++ b/.github/workflows/db-drift.yml
@@ -88,3 +88,18 @@ jobs:
 
       - name: Lint migrations
         run: node scripts/lint-migrations.mjs
+
+  tool-return-coverage:
+    name: MCP tool return-schema coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Check all tools use registerTool() with returns schema
+        run: node scripts/check-tool-return-coverage.mjs


### PR DESCRIPTION
## Summary

- Adds a \`tool-return-coverage\` job to \`.github/workflows/db-drift.yml\` that runs \`scripts/check-tool-return-coverage.mjs\` on every PR/push.
- The script has been on main since 845e22e but no CI job invoked it — a future tool registration that omitted \`returns:\` would land silently.
- Salvaged from the otherwise-stale \`worktree-agent-ac288d8c\` branch (cherry of just the .yml hunk from 804cedc; everything else on that branch is parallel work that already shipped via different SHAs).

## Test plan

- [x] Verified \`node scripts/check-tool-return-coverage.mjs\` passes on current main (43 files scanned, 348 registerTool calls, 0 missing returns).
- [ ] CI green on this PR.