### PR TITLE
feat(deploy): add 'reverse-proxy' TLS source + fix nginx-template path collision

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -249,8 +249,15 @@ services:
       # sed-edit a working copy at /etc/nginx/conf.d/default.conf without
       # touching the read-only mount. Required for the TLS placeholder
       # substitution path.
-      - ./infra/nginx/nginx-with-site.conf:/etc/nginx/templates/site.conf.template:ro
-      - ./infra/nginx/tls-redirect.conf.template:/etc/nginx/templates/tls-redirect.conf.template:ro
+      # Mount the templates outside /etc/nginx/templates/ — that directory
+      # is auto-processed by the nginx:alpine `20-envsubst-on-templates.sh`
+      # script, which would `envsubst` our `__HTTP_LISTEN__` placeholders into
+      # /etc/nginx/conf.d/site.conf as-is (envsubst only handles `${var}`,
+      # not `__FOO__`). nginx then refuses to start on the unsubstituted
+      # directives. Mounting at a sibling path keeps our entrypoint as the
+      # sole consumer of these templates.
+      - ./infra/nginx/nginx-with-site.conf:/etc/nginx/bbb-templates/site.conf.template:ro
+      - ./infra/nginx/tls-redirect.conf.template:/etc/nginx/bbb-templates/tls-redirect.conf.template:ro
       - ./docs/apps:/usr/share/nginx/html/docs/apps:ro
       # TLS certs (gitignored). If empty, entrypoint silently runs HTTP-only.
       - ./certs:/etc/nginx/certs:ro

--- a/docs/local-ssl-notes.md
+++ b/docs/local-ssl-notes.md
@@ -24,7 +24,7 @@ adapter is intentionally untouched.
 
 ## Architecture
 
-**Cert sources (1-of-4 menu, default self-signed):**
+**Cert sources (1-of-5 menu, default self-signed):**
 
 1. **Self-signed** — `openssl req -x509` at deploy time. Browser warns once per device but TLS
    itself works correctly (cookies get the `Secure` flag, HSTS is honored, etc.). Right baseline
@@ -38,6 +38,13 @@ adapter is intentionally untouched.
 4. **Let's Encrypt** — certbot sidecar with HTTP-01 / webroot challenge. Initial issuance runs
    AFTER `docker compose up` because certbot needs nginx serving `/.well-known/acme-challenge/`.
    Renewal is a host-side cron entry, NOT an in-container loop (see "Sharp edges" below).
+5. **External (reverse proxy / CDN handles TLS)** — BBB itself stays plain HTTP; an upstream
+   layer (Cloudflare, Caddy, host nginx, NAS reverse proxy, k8s ingress, etc.) terminates TLS
+   on the public side. No certs are provisioned, no certs mounted, no `listen 443 ssl;` block
+   rendered — the entrypoint runs `TLS_HTTP_MODE=none` and serves only port 80 internally.
+   `formatPublicUrl` still produces `https://domain` (port 443 elided), so `CORS_ORIGIN`,
+   `FRONTEND_URL`, and friends match the browser's `Origin` and `COOKIE_SECURE=true` is still
+   written into `.env`. HSTS is left to the upstream layer (see "Sharp edges" below).
 
 **HTTP-vs-HTTPS coexistence (operator chooses, default redirect):**
 
@@ -59,10 +66,12 @@ flips Fastify's session-cookie `Secure` flag. This single line closes 14 audit f
 ## Sharp edges to avoid (READ BEFORE EXTENDING)
 
 1. **HSTS aggressiveness scales with cert provenance.** Self-signed / mkcert / BYO get
-   `max-age=300`. Only Let's Encrypt gets `max-age=31536000; includeSubDomains`. Reason:
-   permanently poisoning a NAS operator's Chrome HSTS cache for `nas.local` (a hostname they
-   may later move or repurpose) is a footgun with no clean revocation path. The conservative
-   default is intentional — do not "improve" it.
+   `max-age=300`. Only Let's Encrypt gets `max-age=31536000; includeSubDomains`. The
+   reverse-proxy source returns `null` so the upstream layer owns the header (it's the layer
+   that actually terminates TLS, so it's the right place to set policy). Reason for the
+   conservative defaults: permanently poisoning a NAS operator's Chrome HSTS cache for
+   `nas.local` (a hostname they may later move or repurpose) is a footgun with no clean
+   revocation path. Do not "improve" the existing values.
 
 2. **`add_header` directives do not inherit across nginx server blocks.** The existing
    `nginx-with-site.conf` already comments this at the `location /` block. The TLS placeholder
@@ -110,11 +119,6 @@ These items were explicitly considered and deferred. Don't re-relitigate without
   one provider locks operators in; supporting all of them is a big surface. v1 ships HTTP-01
   only with a clear refusal path. If demand comes from a specific provider (Cloudflare, Route
   53, etc.) tackle that one as a follow-up — don't try to abstract.
-
-- **BYO via reverse proxy.** Some operators run nginx-proxy-manager / Caddy / Traefik in front
-  of BBB and want BBB to stay HTTP-only behind that. This works today: just don't opt into
-  TLS. Document the pattern in `docs/deployment-guide.md` if confusion arises, but don't add
-  a "trusted reverse proxy" mode — the existing `useTls=false` path already covers it.
 
 - **Wildcard certs.** Useful when multiple subdomains under the same apex point at this BBB
   install. v1 issues single-name certs only. mkcert and BYO already support wildcards if the

--- a/infra/nginx/entrypoint.sh
+++ b/infra/nginx/entrypoint.sh
@@ -47,8 +47,8 @@ else
 fi
 
 ACTIVE_CONF="/etc/nginx/conf.d/default.conf"
-SITE_TEMPLATE="/etc/nginx/templates/site.conf.template"
-TLS_REDIRECT_TEMPLATE="/etc/nginx/templates/tls-redirect.conf.template"
+SITE_TEMPLATE="/etc/nginx/bbb-templates/site.conf.template"
+TLS_REDIRECT_TEMPLATE="/etc/nginx/bbb-templates/tls-redirect.conf.template"
 TLS_REDIRECT_OUT="/etc/nginx/conf.d/00-tls-redirect.conf"
 CERT_FILE="/etc/nginx/certs/local.crt"
 KEY_FILE="/etc/nginx/certs/local.key"

--- a/infra/nginx/entrypoint.sh
+++ b/infra/nginx/entrypoint.sh
@@ -16,7 +16,7 @@
 #
 # Selection rule: if Railway-injected env vars are present, use railway;
 # otherwise use default. The compose flow ALSO bind-mounts
-# infra/nginx/nginx-with-site.conf at /etc/nginx/templates/site.conf.template
+# infra/nginx/nginx-with-site.conf at /etc/nginx/bbb-templates/site.conf.template
 # (read-only); when present this script copies it over the chosen profile
 # and applies the TLS / HTTP-mode substitutions described below.
 #
@@ -31,7 +31,7 @@
 #     (in those modes a separate /etc/nginx/conf.d/00-tls-redirect.conf
 #     becomes the sole port-80 listener).
 #   - When TLS_HTTP_MODE is redirect or https-only, the
-#     /etc/nginx/templates/tls-redirect.conf.template file is rendered
+#     /etc/nginx/bbb-templates/tls-redirect.conf.template file is rendered
 #     into /etc/nginx/conf.d/00-tls-redirect.conf with __TLS_RETURN__
 #     and __EXT_HTTPS_PORT__ substituted.
 #

--- a/scripts/deploy/shared/summary.mjs
+++ b/scripts/deploy/shared/summary.mjs
@@ -105,11 +105,13 @@ export function printSummary(config) {
       'mkcert': 'mkcert (this machine\'s browsers trust automatically)',
       'byo': 'Bring-your-own (operator-provided cert)',
       'letsencrypt': 'Let\'s Encrypt (real public cert with auto-renewal)',
+      'reverse-proxy': 'External (TLS terminates at upstream proxy / CDN)',
     };
     const modeLabels = {
       redirect: 'redirect (http → https)',
       both: 'both (http and https serve content)',
       'https-only': 'https-only (http connections dropped)',
+      none: 'plain HTTP only (TLS terminates upstream)',
     };
     console.log('');
     console.log(bold('  TLS:\n'));

--- a/scripts/deploy/shared/tls.mjs
+++ b/scripts/deploy/shared/tls.mjs
@@ -25,7 +25,7 @@ import { bold, dim, check, cyan, yellow, red, green, warn } from './colors.mjs';
  * the .env as TLS_CERT_SOURCE so the nginx entrypoint can pick the right
  * HSTS aggressiveness (only "letsencrypt" gets the long-lived header).
  */
-export const CERT_SOURCES = ['self-signed', 'mkcert', 'byo', 'letsencrypt'];
+export const CERT_SOURCES = ['self-signed', 'mkcert', 'byo', 'letsencrypt', 'reverse-proxy'];
 
 /**
  * HTTP-vs-HTTPS coexistence modes. Mirrors what the entrypoint understands.
@@ -198,8 +198,8 @@ function detectWslWithWindowsDocker() {
  * @param {boolean} args.hasOAuth - True when OAuth credentials are
  *   already configured (so we can warn about callback-URL allowlists).
  * @returns {Promise<{
- *   source: 'self-signed' | 'mkcert' | 'byo' | 'letsencrypt',
- *   httpMode: 'redirect' | 'both' | 'https-only',
+ *   source: 'self-signed' | 'mkcert' | 'byo' | 'letsencrypt' | 'reverse-proxy',
+ *   httpMode: 'redirect' | 'both' | 'https-only' | 'none',
  *   byo?: { srcCertPath: string, srcKeyPath: string },
  *   letsencrypt?: { domain: string, email: string, agreeTos: true }
  * } | null>}
@@ -208,12 +208,12 @@ export async function promptTlsConfig({ useTls, httpPort = 80, httpsPort = 443, 
   if (!useTls) return null;
 
   console.log('');
-  console.log(bold('Local TLS / SSL'));
-  console.log(dim('  You opted into https-style URLs in the previous step. Now we need to'));
-  console.log(dim('  put a certificate behind that promise — without one, nginx will keep'));
-  console.log(dim('  serving plain HTTP and your browsers will fail with cookie/CORS errors.'));
+  console.log(bold('TLS / SSL'));
+  console.log(dim('  You opted into https-style URLs in the previous step. Pick where TLS'));
+  console.log(dim('  is handled — BBB itself (one of four cert sources below) or an upstream'));
+  console.log(dim('  layer that already terminates it (reverse proxy, CDN, ingress, etc.).'));
   console.log('');
-  console.log(dim('  Four options below; pick the first one unless you know better.'));
+  console.log(dim('  Pick the first one unless you know better.'));
   console.log('');
 
   const mkcertPath = detectMkcert();
@@ -222,13 +222,14 @@ export async function promptTlsConfig({ useTls, httpPort = 80, httpsPort = 443, 
     { label: 'Bring your own cert + key', value: 'byo', description: 'You already have a .crt and .key from somewhere (corp PKI, wildcard, etc.). We copy them into place.' },
     { label: mkcertPath ? `mkcert (detected at ${mkcertPath})` : 'mkcert (not installed)', value: 'mkcert', description: mkcertPath ? 'Issues a cert signed by mkcert\'s local CA. THIS machine\'s browsers trust automatically.' : 'mkcert is not on PATH. Install it first or pick another option.' },
     { label: 'Let\'s Encrypt (real public cert)', value: 'letsencrypt', description: 'Auto-issues a real cert via certbot. Requires a public domain pointing at this host with port 80 reachable from the internet.' },
+    { label: 'External (reverse proxy / CDN handles TLS)', value: 'reverse-proxy', description: 'BBB stays plain HTTP and URLs declare https://. Pick this when fronted by Cloudflare, Caddy, host nginx, NAS reverse proxy, k8s ingress, etc.' },
   ];
 
-  let source = await select('How should TLS certs be provisioned?', sourceOptions);
+  let source = await select('How is TLS handled for this deployment?', sourceOptions);
 
   if (source === 'mkcert' && !mkcertPath) {
     console.log(`  ${red('mkcert not on PATH.')} Install it (https://github.com/FiloSottile/mkcert) or pick another option.`);
-    source = await select('How should TLS certs be provisioned?', sourceOptions.filter((o) => o.value !== 'mkcert'));
+    source = await select('How is TLS handled for this deployment?', sourceOptions.filter((o) => o.value !== 'mkcert'));
   }
 
   if (source === 'mkcert' && detectWslWithWindowsDocker()) {
@@ -301,33 +302,42 @@ export async function promptTlsConfig({ useTls, httpPort = 80, httpsPort = 443, 
     }
   }
 
-  // HTTP-vs-HTTPS coexistence prompt (ELI5).
-  console.log('');
-  console.log(bold('  HTTP and HTTPS coexistence'));
-  console.log(dim('  Once TLS is in place, what should happen when someone visits the plain'));
-  console.log(dim('  http:// URL? Three options:'));
-  console.log('');
-  console.log(`    ${cyan('redirect')}    — http requests bounce to https (recommended)`);
-  console.log(dim('                Bookmarks and old links keep working. Cookies stay safe.'));
-  console.log(dim('                The right default for any deployment.'));
-  console.log('');
-  console.log(`    ${cyan('both')}        — http and https BOTH serve the app`);
-  console.log(dim('                Useful if you have internal LAN scripts or monitoring tools'));
-  console.log(dim('                that hit the app over plain http and you can\'t change them.'));
-  console.log(`                ${yellow('Caveat:')} login may silently fail if the user lands on http`);
-  console.log(dim('                first — browsers refuse to store the secure session cookie.'));
-  console.log('');
-  console.log(`    ${cyan('https-only')}  — http requests are dropped (connection close)`);
-  console.log(dim('                Strictest posture. Pick this if you actively do not want'));
-  console.log(dim('                ANY plain-http traffic, including health probes from a LAN'));
-  console.log(dim('                that you control.'));
-  console.log('');
+  // HTTP-vs-HTTPS coexistence prompt (ELI5). Only relevant when BBB itself
+  // serves TLS. With the 'reverse-proxy' source the entrypoint always runs
+  // plain HTTP on the configured port; the upstream layer owns the redirect
+  // / coexistence policy on its side. Pin httpMode='none' here so downstream
+  // code (env writing, entrypoint, summary) sees a well-defined value.
+  let httpMode;
+  if (source === 'reverse-proxy') {
+    httpMode = 'none';
+  } else {
+    console.log('');
+    console.log(bold('  HTTP and HTTPS coexistence'));
+    console.log(dim('  Once TLS is in place, what should happen when someone visits the plain'));
+    console.log(dim('  http:// URL? Three options:'));
+    console.log('');
+    console.log(`    ${cyan('redirect')}    — http requests bounce to https (recommended)`);
+    console.log(dim('                Bookmarks and old links keep working. Cookies stay safe.'));
+    console.log(dim('                The right default for any deployment.'));
+    console.log('');
+    console.log(`    ${cyan('both')}        — http and https BOTH serve the app`);
+    console.log(dim('                Useful if you have internal LAN scripts or monitoring tools'));
+    console.log(dim('                that hit the app over plain http and you can\'t change them.'));
+    console.log(`                ${yellow('Caveat:')} login may silently fail if the user lands on http`);
+    console.log(dim('                first — browsers refuse to store the secure session cookie.'));
+    console.log('');
+    console.log(`    ${cyan('https-only')}  — http requests are dropped (connection close)`);
+    console.log(dim('                Strictest posture. Pick this if you actively do not want'));
+    console.log(dim('                ANY plain-http traffic, including health probes from a LAN'));
+    console.log(dim('                that you control.'));
+    console.log('');
 
-  const httpMode = await select('Coexistence mode for HTTP and HTTPS?', [
-    { label: 'redirect (recommended)', value: 'redirect', description: 'Most deployments want this.' },
-    { label: 'both', value: 'both', description: 'Keeps plain http working alongside https.' },
-    { label: 'https-only', value: 'https-only', description: 'Drops plain http connections entirely.' },
-  ]);
+    httpMode = await select('Coexistence mode for HTTP and HTTPS?', [
+      { label: 'redirect (recommended)', value: 'redirect', description: 'Most deployments want this.' },
+      { label: 'both', value: 'both', description: 'Keeps plain http working alongside https.' },
+      { label: 'https-only', value: 'https-only', description: 'Drops plain http connections entirely.' },
+    ]);
+  }
 
   // OAuth callback warning — only relevant when OAuth is configured AND we're
   // about to switch the scheme. The callback URL allowlisted in the provider
@@ -375,6 +385,10 @@ export function provisionCerts(tlsConfig, { domain, certsDir }) {
       // Deferred. The LE flow needs nginx up to serve the ACME challenge,
       // so docker-compose.mjs runs the certbot sidecar after `up`.
       return null;
+    case 'reverse-proxy':
+      // No certs to provision — an upstream layer terminates TLS. The
+      // entrypoint sees TLS_HTTP_MODE=none and keeps nginx on plain HTTP.
+      return null;
     default:
       throw new Error(`Unknown TLS cert source: ${tlsConfig.source}`);
   }
@@ -388,5 +402,9 @@ export function provisionCerts(tlsConfig, { domain, certsDir }) {
  */
 export function pickHstsHeader(source) {
   if (source === 'letsencrypt') return 'max-age=31536000; includeSubDomains';
+  // External-TLS deployments leave HSTS to the upstream proxy/CDN — that's
+  // the layer that actually handles TLS, so it's the right place to set the
+  // header (and it almost certainly has its own opinions about max-age).
+  if (source === 'reverse-proxy') return null;
   return 'max-age=300';
 }

--- a/scripts/deploy/shared/tls.test.mjs
+++ b/scripts/deploy/shared/tls.test.mjs
@@ -3,15 +3,27 @@
 // generated cert/key files are real and the validateCertKeyPair pairing
 // check is exercised end-to-end.
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+
+vi.mock('./prompt.mjs', () => ({
+  ask: vi.fn(),
+  askPassword: vi.fn(),
+  confirm: vi.fn(),
+  select: vi.fn(),
+  banner: vi.fn(),
+}));
+
+import { select } from './prompt.mjs';
 import {
   pickHstsHeader,
   generateSelfSigned,
   validateCertKeyPair,
   detectMkcert,
+  provisionCerts,
+  promptTlsConfig,
   CERT_SOURCES,
   HTTP_MODES,
 } from './tls.mjs';
@@ -30,6 +42,10 @@ describe('pickHstsHeader', () => {
     expect(pickHstsHeader('byo')).toBe('max-age=300');
   });
 
+  it('returns null for reverse-proxy (HSTS belongs to the upstream layer)', () => {
+    expect(pickHstsHeader('reverse-proxy')).toBeNull();
+  });
+
   it('falls back to max-age=300 for unknown sources', () => {
     expect(pickHstsHeader('something-else')).toBe('max-age=300');
     expect(pickHstsHeader(undefined)).toBe('max-age=300');
@@ -37,12 +53,13 @@ describe('pickHstsHeader', () => {
 });
 
 describe('CERT_SOURCES + HTTP_MODES enums', () => {
-  it('exposes the four cert sources', () => {
+  it('exposes the five cert sources including reverse-proxy', () => {
     expect(CERT_SOURCES).toContain('self-signed');
     expect(CERT_SOURCES).toContain('mkcert');
     expect(CERT_SOURCES).toContain('byo');
     expect(CERT_SOURCES).toContain('letsencrypt');
-    expect(CERT_SOURCES).toHaveLength(4);
+    expect(CERT_SOURCES).toContain('reverse-proxy');
+    expect(CERT_SOURCES).toHaveLength(5);
   });
 
   it('exposes the three http modes', () => {
@@ -103,5 +120,71 @@ describe('generateSelfSigned + validateCertKeyPair', () => {
     const validation = validateCertKeyPair('/nonexistent/cert.pem', '/nonexistent/key.pem');
     expect(validation.ok).toBe(false);
     expect(validation.reason).toMatch(/not found/i);
+  });
+});
+
+describe('provisionCerts — reverse-proxy', () => {
+  let tmpDir;
+  afterEach(() => {
+    if (tmpDir && fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null and writes nothing for source=reverse-proxy', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bbb-tls-test-'));
+    const result = provisionCerts(
+      { source: 'reverse-proxy', httpMode: 'none', byo: null, letsencrypt: null },
+      { domain: 'bbb.example.com', certsDir: tmpDir },
+    );
+    expect(result).toBeNull();
+    // The certs directory should not be created or populated by the
+    // reverse-proxy path — an upstream layer holds the cert material.
+    if (fs.existsSync(tmpDir)) {
+      expect(fs.readdirSync(tmpDir)).toEqual([]);
+    }
+  });
+});
+
+describe('promptTlsConfig — reverse-proxy', () => {
+  beforeEach(() => {
+    select.mockReset();
+  });
+
+  it('returns the reverse-proxy shape when picked on the first prompt', async () => {
+    select.mockResolvedValueOnce('reverse-proxy');
+
+    const result = await promptTlsConfig({ useTls: true, httpPort: 80, httpsPort: 443 });
+
+    // byo/letsencrypt are optional (`?:` in the JSDoc) and conditionally
+    // spread, so they're absent from the return when unset.
+    expect(result).toEqual({ source: 'reverse-proxy', httpMode: 'none' });
+    // Only one select should have fired — the cert-source picker. The
+    // HTTP-coexistence prompt is suppressed for this source because the
+    // entrypoint ignores it (TLS_HTTP_MODE=none → plain HTTP only).
+    expect(select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the reverse-proxy shape when picked via the LE-port-mismatch fallback', async () => {
+    // Operator initially picked LE; HTTP_PORT is non-default so LE refuses
+    // and the script offers a fallback select. Operator then picks
+    // reverse-proxy from the fallback. Final config should still be the
+    // clean reverse-proxy shape.
+    select.mockResolvedValueOnce('letsencrypt');
+    select.mockResolvedValueOnce('reverse-proxy');
+
+    const result = await promptTlsConfig({ useTls: true, httpPort: 18080, httpsPort: 443 });
+
+    expect(result).toEqual({
+      source: 'reverse-proxy',
+      httpMode: 'none',
+    });
+    expect(select).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null when useTls is false (existing behavior pinned)', async () => {
+    const result = await promptTlsConfig({ useTls: false, httpPort: 80, httpsPort: 443 });
+    expect(result).toBeNull();
+    expect(select).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Rebase of @leith-bartrich's PR #19 onto current main. PR #19 was closed unmerged after its base branch (\`local-ssl\`) was merged via PR #20; this preserves Brad's authorship on the substantive commit and brings the work back to life on the right base.

Two changes:

### 1. New 'reverse-proxy' TLS source (5th cert-source option)

For deploys where an upstream layer (Cloudflare, Caddy, host nginx, NAS reverse proxy, k8s ingress, etc.) terminates TLS and BBB itself stays plain HTTP. Closes the gap where the four existing cert-source paths all assume BBB serves TLS, and the documented \"BYO via reverse proxy / just don't opt into TLS\" workaround silently breaks CORS — \`useTls=false\` keeps BBB on HTTP correctly, but \`formatPublicUrl\` then writes \`http://domain:port\` URLs that mismatch the browser's \`https://domain\` Origin.

Picking 'reverse-proxy':
- Skips cert provisioning (\`provisionCerts\` returns null)
- Pins \`TLS_HTTP_MODE=none\` so the entrypoint serves only port 80
- Pins \`httpMode='none'\` in the returned config so the HTTP-coexistence prompt is correctly suppressed
- Leaves HSTS to the upstream layer (\`pickHstsHeader\` returns null)
- Still writes \`COOKIE_SECURE=true\` since URLs are https-form

Reachable via the LE-port-mismatch fallback select too: an operator who initially picked Let's Encrypt with \`HTTP_PORT != 80\` can pivot to reverse-proxy from the fallback prompt.

### 2. Critical blocker fix (nginx-template path collision)

\`local-ssl\` as-shipped on main causes the frontend container to fail to start with \`nginx: [emerg] unknown directive \"__HTTP_LISTEN__\"\` because the bind-mounted templates land in \`/etc/nginx/templates/\`, which the nginx:alpine official entrypoint auto-processes via \`20-envsubst-on-templates.sh\`. envsubst only handles \`\${var}\` syntax, not \`__FOO__\`, so the unmodified template ends up in \`/etc/nginx/conf.d/\` alongside the file my entrypoint produces — and nginx loads both.

Fix: move the bind-mount path to \`/etc/nginx/bbb-templates/\` (a name nginx:alpine doesn't auto-process), so the custom entrypoint becomes the sole consumer of the template files. **This bug is on main right now**; without this fix, every \`docker compose up\` after a fresh \`local-ssl\` deploy fails to come up healthy.

## Caveats Brad flagged for triage (carried over from PR #19)

1. **URL formation breaks with non-default \`HTTPS_PORT\` in reverse-proxy mode.** When \`HTTPS_PORT\` is remapped (e.g. 8443) AND source=\`reverse-proxy\`, \`formatPublicUrl({ httpsPort: 8443 })\` produces \`https://domain:8443\`. Workaround today: keep \`HTTPS_PORT=443\`. Right fix: override \`httpsPort\` to 443 for URL formation in \`secrets.mjs::buildEnvConfig\` when \`tlsConfig.source === 'reverse-proxy'\`.

2. **\`HTTPS_PORT\` host-side bind is wasted in reverse-proxy mode.** \`docker-compose.yml\` publishes \`\${HTTPS_PORT:-443}:443\` regardless of \`TLS_HTTP_MODE\`. Cleanup is a conditional publish.

3. **Prompt order: TLS architecture should arguably come before port mapping.** Currently ports are asked first, TLS source second. TLS source is the more fundamental decision and should dictate which ports to ask about. Substantial restructure.

4. **LiveKit untouched.** Reverse-proxy fronting for LiveKit's signaling/TCP/UDP is a separate problem. Operators in this mode pick \"Skip for now\" at the LiveKit prompt.

5. **Naming.** \`'reverse-proxy'\` enum value — open to \`'external'\`, \`'upstream'\`, \`'fronted'\`.

## Tests

- 121 prior deploy-script tests still pass.
- 5 new in \`tls.test.mjs\` (\`pickHstsHeader('reverse-proxy')\` returns null; \`CERT_SOURCES\` length bumped to 5; \`provisionCerts\` returns null; \`promptTlsConfig\` shape on first-pick path; \`promptTlsConfig\` shape via LE-port-mismatch fallback path).
- Verified locally: \`pnpm dlx vitest run\` → 126/126 green.

## File touch summary

- \`docker-compose.yml\`, \`infra/nginx/entrypoint.sh\` — nginx-template path move (\`/etc/nginx/bbb-templates/\`)
- \`scripts/deploy/shared/tls.mjs\` — 5th option, \`provisionCerts\`/\`pickHstsHeader\` cases, prompt header reframe
- \`scripts/deploy/shared/summary.mjs\` — label dictionary entries
- \`scripts/deploy/shared/tls.test.mjs\` — 5 new tests
- \`docs/local-ssl-notes.md\` — Architecture section + strike \"BYO via reverse proxy\" deferred entry + HSTS sharp-edge note

Plus a follow-up commit from me aligning two stale doc-comment lines in \`entrypoint.sh\` with the new path.

## Test plan

- [x] Unit tests green on the branch (\`pnpm dlx vitest run\` → 126/126)
- [x] Frontend container boots clean (no \`unknown directive\` errors)
- [x] Live deploy with \`HTTP_PORT=8080\`, \`HTTPS_PORT=443\`, source=reverse-proxy produces correct \`.env\` (Brad's testing in PR #19)
- [ ] Test passes for non-default \`HTTPS_PORT\` once caveat #1 follow-up commit lands
- [ ] Maintainer triage of caveats above

---

Original PR: #19 (closed without merging). Authorship of the substantive commit is preserved as Bradley Friedman <brad@fie.us>.