### PR TITLE
fix(deploy): pin COOKIE_SECURE=false on HTTP-only deploys

### DIFF
--- a/scripts/deploy/shared/secrets.mjs
+++ b/scripts/deploy/shared/secrets.mjs
@@ -322,6 +322,12 @@ export function buildEnvConfig(choices) {
       env.LETSENCRYPT_EMAIL = tlsConfig.letsencrypt.email;
       env.LETSENCRYPT_AGREE_TOS = tlsConfig.letsencrypt.agreeTos ? 'true' : 'false';
     }
+  } else {
+    // HTTP-only deploy (no TLS). Must pin COOKIE_SECURE=false explicitly:
+    // apps/api/src/env.ts defaults it to true when NODE_ENV=production, which
+    // makes browsers silently drop the Set-Cookie over plain HTTP and every
+    // post-login request 401s. See BAM-010.
+    env.COOKIE_SECURE = 'false';
   }
 
   return env;


### PR DESCRIPTION
## Summary

- `apps/api/src/env.ts` defaults `COOKIE_SECURE=true` when `NODE_ENV=production`, which causes browsers to silently drop `Set-Cookie` headers over plain HTTP
- Every post-login request 401s on HTTP-only deployments (no reverse proxy / no TLS) because the session cookie is never stored
- The deploy script now explicitly writes `COOKIE_SECURE=false` into `.env` when the operator selects the HTTP-only path; TLS/reverse-proxy paths continue to set it `true`

## Affected file

`scripts/deploy/shared/secrets.mjs` — adds the `COOKIE_SECURE` key in the `else` branch of the HTTP/HTTPS decision already present in that function.

## Test plan

- [ ] Fresh HTTP-only Docker Compose deploy: log in, confirm session cookie is persisted and subsequent API calls return 200 (not 401)
- [ ] HTTPS / reverse-proxy deploy: confirm `COOKIE_SECURE=true` is still written and behaviour is unchanged
- [ ] Re-run of deploy script on existing `.env` (idempotent path): confirm no duplicate keys introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)