### PR TITLE
fix(api): notify member and log activity on project membership add

### DIFF
--- a/apps/api/src/routes/project.routes.ts
+++ b/apps/api/src/routes/project.routes.ts
@@ -277,6 +277,7 @@ export default async function projectRoutes(fastify: FastifyInstance) {
         request.params.id,
         data.user_id,
         data.role,
+        request.user!.id,
       );
       await invalidateProjectListsForProject(fastify.redis, request.params.id);
 

--- a/apps/api/src/services/notification-fanout.service.ts
+++ b/apps/api/src/services/notification-fanout.service.ts
@@ -17,6 +17,9 @@
 import IORedis from 'ioredis';
 import { Queue } from 'bullmq';
 import { env } from '../env.js';
+import type { NotificationJobData } from '@bigbluebam/shared';
+
+export type { NotificationJobData };
 
 // ---------------------------------------------------------------------------
 // Types
@@ -61,6 +64,18 @@ function getEmailQueue(): Queue {
     _emailQueue = new Queue('email', { connection });
   }
   return _emailQueue;
+}
+
+let _notificationsQueue: Queue | null = null;
+
+function getNotificationsQueue(): Queue {
+  if (!_notificationsQueue) {
+    const connection = new IORedis(env.REDIS_URL, {
+      maxRetriesPerRequest: null,
+    });
+    _notificationsQueue = new Queue('notifications', { connection });
+  }
+  return _notificationsQueue;
 }
 
 // ---------------------------------------------------------------------------
@@ -185,5 +200,23 @@ export async function fanoutNotification(
     r.status === 'fulfilled'
       ? r.value
       : { channel: 'email' as NotificationChannel, status: 'error' as const, error: String(r.reason) },
+  );
+}
+
+/**
+ * Enqueue a persistent notification into the `notifications` BullMQ queue.
+ * The worker picks this up and inserts a row into the `notifications` table,
+ * which is what `list_my_notifications` reads.
+ */
+export async function enqueueNotification(data: NotificationJobData): Promise<void> {
+  await getNotificationsQueue().add(
+    `notif-${data.user_id}-${Date.now()}`,
+    data,
+    {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 5_000 },
+      removeOnComplete: 100,
+      removeOnFail: 500,
+    },
   );
 }

--- a/apps/api/src/services/project.service.ts
+++ b/apps/api/src/services/project.service.ts
@@ -6,6 +6,8 @@ import { phases } from '../db/schema/phases.js';
 import { taskStates } from '../db/schema/task-states.js';
 import { sprints } from '../db/schema/sprints.js';
 import type { CreateProjectInput, UpdateProjectInput } from '@bigbluebam/shared';
+import { logActivity } from './activity.service.js';
+import { enqueueNotification } from './notification-fanout.service.js';
 
 function slugify(text: string): string {
   return text
@@ -298,7 +300,12 @@ export async function getProjectMembers(projectId: string) {
   }));
 }
 
-export async function addProjectMember(projectId: string, userId: string, role: string) {
+export async function addProjectMember(
+  projectId: string,
+  userId: string,
+  role: string,
+  actorId?: string,
+) {
   const [membership] = await db
     .insert(projectMemberships)
     .values({
@@ -307,6 +314,29 @@ export async function addProjectMember(projectId: string, userId: string, role: 
       role,
     })
     .returning();
+
+  if (actorId) {
+    logActivity(projectId, actorId, 'member.added', membership!.id, { user_id: userId, role }).catch(() => {});
+
+    const { users: usersTable } = await import('../db/schema/users.js');
+    Promise.all([
+      db.select({ name: projects.name }).from(projects).where(eq(projects.id, projectId)).limit(1),
+      db.select({ name: usersTable.display_name }).from(usersTable).where(eq(usersTable.id, actorId)).limit(1),
+    ]).then(([[project], [actor]]) => {
+      const projectName = project?.name ?? 'a project';
+      const actorName = actor?.name ?? 'Someone';
+      enqueueNotification({
+        user_id: userId,
+        project_id: projectId,
+        type: 'project.member_added',
+        category: 'membership_added',
+        source_app: 'bbb',
+        title: `Added to project: ${projectName}`,
+        body: `${actorName} added you to "${projectName}" as ${role}.`,
+        deep_link: `/b3/projects/${projectId}`,
+      });
+    }).catch(() => {});
+  }
 
   return membership!;
 }

--- a/apps/api/src/services/task.service.ts
+++ b/apps/api/src/services/task.service.ts
@@ -13,7 +13,7 @@ import { env } from '../env.js';
 import { escapeLike } from '../lib/escape-like.js';
 import { publishBoltEvent } from '../lib/bolt-events.js';
 import { enrichTask, loadActor, loadOrg, loadPhase } from './bolt-event-enricher.service.js';
-import { fanoutNotification } from './notification-fanout.service.js';
+import { fanoutNotification, enqueueNotification } from './notification-fanout.service.js';
 
 /** Look up org_id for a project (used for Bolt event publishing). */
 async function getProjectOrgId(projectId: string): Promise<string | null> {
@@ -261,26 +261,40 @@ export async function updateTask(taskId: string, data: UpdateTaskInput, actorId?
       );
 
       // Cross-product notification fan-out: when a task is assigned,
-      // notify the new assignee via email + Banter DM (G6).
+      // notify the new assignee via email + Banter DM (G6) and persist
+      // a notification row via the notifications queue.
       if (
         data.assignee_id &&
         enriched.assignee &&
         data.assignee_id !== actorId
       ) {
+        const notifTitle = `Task assigned: ${task.title}`;
+        const notifBody = `${actor?.name ?? 'Someone'} assigned you to "${task.title}" in project ${enriched.project?.name ?? 'unknown'}.`;
+
         fanoutNotification(
           {
             recipient_user_id: data.assignee_id,
             recipient_email: enriched.assignee.email ?? undefined,
-            subject: `Task assigned: ${task.title}`,
-            body: `${actor?.name ?? 'Someone'} assigned you to "${task.title}" in project ${enriched.project?.name ?? 'unknown'}.`,
+            subject: notifTitle,
+            body: notifBody,
             url: `/b3/tasks/${task.id}`,
             org_id: orgId,
             actor_name: actor?.name ?? undefined,
           },
           ['email', 'banter_dm'],
-        ).catch(() => {
-          // Fire-and-forget; never block task updates on notification failures.
-        });
+        ).catch(() => {});
+
+        enqueueNotification({
+          user_id: data.assignee_id,
+          project_id: task.project_id,
+          task_id: task.id,
+          type: 'task.assigned',
+          category: 'assignment',
+          source_app: 'bbb',
+          title: notifTitle,
+          body: notifBody,
+          deep_link: `/b3/tasks/${task.id}`,
+        }).catch(() => {});
       }
     }).catch(() => {});
   }

--- a/apps/api/test/notification-fanout.test.ts
+++ b/apps/api/test/notification-fanout.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------- mocks ----------
+const { mockQueueAdd } = vi.hoisted(() => {
+  const mockQueueAdd: Record<string, ReturnType<typeof vi.fn>> = {};
+  return { mockQueueAdd };
+});
+
+vi.mock('bullmq', () => ({
+  Queue: vi.fn().mockImplementation((name: string) => {
+    if (!mockQueueAdd[name]) {
+      mockQueueAdd[name] = vi.fn().mockResolvedValue({ id: 'job-1' });
+    }
+    return { add: mockQueueAdd[name] };
+  }),
+}));
+
+vi.mock('ioredis', () => ({
+  default: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../src/env.js', () => ({
+  env: {
+    REDIS_URL: 'redis://localhost:6379',
+    NODE_ENV: 'test',
+  },
+}));
+
+// ---------- import (after mocks) ----------
+import { enqueueNotification } from '../src/services/notification-fanout.service.js';
+
+// ---------- tests ----------
+describe('enqueueNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enqueues to the notifications queue', async () => {
+    await enqueueNotification({
+      user_id: 'user-1',
+      project_id: 'proj-1',
+      task_id: 'task-1',
+      type: 'task.assigned',
+      title: 'Task assigned: Fix login bug',
+      body: 'Alice assigned you to "Fix login bug" in project Acme.',
+      category: 'assignment',
+      source_app: 'bbb',
+      deep_link: '/b3/tasks/task-1',
+    });
+
+    expect(mockQueueAdd['notifications']).toHaveBeenCalledTimes(1);
+  });
+
+  it('job payload matches the data passed in', async () => {
+    const data = {
+      user_id: 'user-1',
+      project_id: 'proj-1',
+      task_id: 'task-1',
+      type: 'task.assigned',
+      title: 'Task assigned: Fix login bug',
+      body: 'Alice assigned you to "Fix login bug" in project Acme.',
+      category: 'assignment',
+      source_app: 'bbb',
+      deep_link: '/b3/tasks/task-1',
+    };
+
+    await enqueueNotification(data);
+
+    expect(mockQueueAdd['notifications']).toHaveBeenCalledWith(
+      expect.stringContaining('notif-user-1-'),
+      expect.objectContaining(data),
+      expect.objectContaining({ attempts: 3 }),
+    );
+  });
+
+  it('uses retry options with exponential backoff', async () => {
+    await enqueueNotification({
+      user_id: 'user-1',
+      project_id: 'proj-1',
+      type: 'task.assigned',
+      title: 'Test',
+      body: 'Test body',
+    });
+
+    expect(mockQueueAdd['notifications']).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 5_000 },
+      }),
+    );
+  });
+});

--- a/apps/api/test/project-membership-notification.test.ts
+++ b/apps/api/test/project-membership-notification.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------- mocks ----------
+const { mockDb, mockQueueAdd } = vi.hoisted(() => {
+  const mockDb = {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+    execute: vi.fn(),
+  };
+  const mockQueueAdd: Record<string, ReturnType<typeof vi.fn>> = {};
+  return { mockDb, mockQueueAdd };
+});
+
+vi.mock('bullmq', () => ({
+  Queue: vi.fn().mockImplementation((name: string) => {
+    if (!mockQueueAdd[name]) {
+      mockQueueAdd[name] = vi.fn().mockResolvedValue({ id: 'job-1' });
+    }
+    return { add: mockQueueAdd[name] };
+  }),
+}));
+
+vi.mock('ioredis', () => ({
+  default: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../src/db/index.js', () => ({
+  db: mockDb,
+  connection: { end: vi.fn() },
+}));
+
+vi.mock('../src/services/activity.service.js', () => ({
+  logActivity: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../src/env.js', () => ({
+  env: {
+    SESSION_TTL_SECONDS: 604800,
+    DATABASE_URL: 'postgres://test:test@localhost:5432/test',
+    NODE_ENV: 'test',
+    PORT: 4000,
+    HOST: '0.0.0.0',
+    SESSION_SECRET: 'a'.repeat(32),
+    REDIS_URL: 'redis://localhost:6379',
+    CORS_ORIGIN: 'http://localhost:3000',
+    LOG_LEVEL: 'info',
+    RATE_LIMIT_MAX: 100,
+    RATE_LIMIT_WINDOW_MS: 60000,
+    UPLOAD_MAX_FILE_SIZE: 10485760,
+    UPLOAD_ALLOWED_TYPES: 'image/*',
+    COOKIE_SECURE: false,
+  },
+}));
+
+// ---------- imports (after mocks) ----------
+import { addProjectMember } from '../src/services/project.service.js';
+import { logActivity } from '../src/services/activity.service.js';
+
+// ---------- fixtures ----------
+const PROJECT_ID = 'aaaaaaaa-0000-0000-0000-000000000001';
+const USER_ID    = 'bbbbbbbb-0000-0000-0000-000000000001';
+const ACTOR_ID   = 'cccccccc-0000-0000-0000-000000000001';
+const MEMBERSHIP_ID = 'dddddddd-0000-0000-0000-000000000001';
+
+const fakeMembership = {
+  id: MEMBERSHIP_ID,
+  project_id: PROJECT_ID,
+  user_id: USER_ID,
+  role: 'member',
+  created_at: new Date(),
+};
+
+// ---------- helpers ----------
+function setupInsert() {
+  const returning = vi.fn().mockResolvedValue([fakeMembership]);
+  const values = vi.fn().mockReturnValue({ returning });
+  mockDb.insert.mockReturnValue({ values });
+}
+
+// Two selects fire in Promise.all: first for project name, second for actor name.
+function setupSelects(projectName = 'Test Project', actorName = 'Actor User') {
+  const makeSelect = (row: object) => {
+    const limit = vi.fn().mockResolvedValue([row]);
+    const where = vi.fn().mockReturnValue({ limit });
+    const from = vi.fn().mockReturnValue({ where });
+    return { from };
+  };
+  mockDb.select
+    .mockReturnValueOnce(makeSelect({ name: projectName }))
+    .mockReturnValueOnce(makeSelect({ name: actorName }));
+}
+
+// ---------- tests ----------
+describe('project membership add → activity log + notifications queue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls logActivity with member.added when actorId is provided', async () => {
+    setupInsert();
+    setupSelects();
+
+    await addProjectMember(PROJECT_ID, USER_ID, 'member', ACTOR_ID);
+
+    expect(vi.mocked(logActivity)).toHaveBeenCalledWith(
+      PROJECT_ID,
+      ACTOR_ID,
+      'member.added',
+      MEMBERSHIP_ID,
+      expect.objectContaining({ user_id: USER_ID, role: 'member' }),
+    );
+  });
+
+  it('enqueues a notifications job for the new member', async () => {
+    setupInsert();
+    setupSelects();
+
+    await addProjectMember(PROJECT_ID, USER_ID, 'member', ACTOR_ID);
+
+    await vi.waitFor(() => {
+      expect(mockQueueAdd['notifications']).toBeDefined();
+      expect(mockQueueAdd['notifications']).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          user_id: USER_ID,
+          project_id: PROJECT_ID,
+          type: 'project.member_added',
+        }),
+        expect.any(Object),
+      );
+    }, { timeout: 2000 });
+  });
+
+  it('notification has correct category and source_app', async () => {
+    setupInsert();
+    setupSelects();
+
+    await addProjectMember(PROJECT_ID, USER_ID, 'member', ACTOR_ID);
+
+    await vi.waitFor(() => {
+      expect(mockQueueAdd['notifications']).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          category: 'membership_added',
+          source_app: 'bbb',
+        }),
+        expect.any(Object),
+      );
+    }, { timeout: 2000 });
+  });
+
+  it('does not enqueue when no actorId is provided', async () => {
+    setupInsert();
+
+    await addProjectMember(PROJECT_ID, USER_ID, 'member');
+
+    // Allow any pending microtasks to settle before asserting.
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(mockQueueAdd['notifications']?.mock?.calls ?? []).toHaveLength(0);
+    expect(vi.mocked(logActivity)).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/test/task-notification.test.ts
+++ b/apps/api/test/task-notification.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------- mocks ----------
+const { mockDb, mockQueueAdd } = vi.hoisted(() => {
+  const mockDb = {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+    execute: vi.fn(),
+  };
+  // Capture add() calls keyed by queue name so we can assert per-queue.
+  const mockQueueAdd: Record<string, ReturnType<typeof vi.fn>> = {};
+  return { mockDb, mockQueueAdd };
+});
+
+vi.mock('bullmq', () => ({
+  Queue: vi.fn().mockImplementation((name: string) => {
+    if (!mockQueueAdd[name]) {
+      mockQueueAdd[name] = vi.fn().mockResolvedValue({ id: 'job-1' });
+    }
+    return { add: mockQueueAdd[name] };
+  }),
+}));
+
+vi.mock('ioredis', () => ({
+  default: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../src/db/index.js', () => ({
+  db: mockDb,
+  connection: { end: vi.fn() },
+}));
+
+vi.mock('../src/services/realtime.service.js', () => ({
+  broadcastToProject: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../src/services/activity.service.js', () => ({
+  logActivity: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../src/services/slack-notify.service.js', () => ({
+  postToSlack: vi.fn().mockResolvedValue(undefined),
+  taskDeepLink: vi.fn().mockReturnValue('/b3/tasks/task-1'),
+}));
+
+vi.mock('../src/lib/bolt-events.js', () => ({
+  publishBoltEvent: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock('../src/services/bolt-event-enricher.service.js', () => ({
+  enrichTask: vi.fn(),
+  loadActor: vi.fn(),
+  loadOrg: vi.fn(),
+  loadPhase: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../src/env.js', () => ({
+  env: {
+    SESSION_TTL_SECONDS: 604800,
+    DATABASE_URL: 'postgres://test:test@localhost:5432/test',
+    NODE_ENV: 'test',
+    PORT: 4000,
+    HOST: '0.0.0.0',
+    SESSION_SECRET: 'a'.repeat(32),
+    REDIS_URL: 'redis://localhost:6379',
+    CORS_ORIGIN: 'http://localhost:3000',
+    LOG_LEVEL: 'info',
+    RATE_LIMIT_MAX: 100,
+    RATE_LIMIT_WINDOW_MS: 60000,
+    UPLOAD_MAX_FILE_SIZE: 10485760,
+    UPLOAD_ALLOWED_TYPES: 'image/*',
+    COOKIE_SECURE: false,
+  },
+}));
+
+// ---------- imports (after mocks) ----------
+import { updateTask } from '../src/services/task.service.js';
+import { enrichTask, loadActor, loadOrg } from '../src/services/bolt-event-enricher.service.js';
+import { publishBoltEvent } from '../src/lib/bolt-events.js';
+
+// ---------- fixtures ----------
+const now = new Date();
+const TASK_ID = 'aaaaaaaa-0000-0000-0000-000000000001';
+const PROJECT_ID = 'bbbbbbbb-0000-0000-0000-000000000001';
+const ACTOR_ID = 'cccccccc-0000-0000-0000-000000000001';
+const ASSIGNEE_ID = 'dddddddd-0000-0000-0000-000000000001';
+const ORG_ID = 'eeeeeeee-0000-0000-0000-000000000001';
+
+const fakeTask = {
+  id: TASK_ID,
+  project_id: PROJECT_ID,
+  human_id: 'TST-1',
+  parent_task_id: null,
+  title: 'Fix the login bug',
+  description: null,
+  phase_id: 'phase-1',
+  state_id: 'state-1',
+  sprint_id: null,
+  epic_id: null,
+  assignee_id: ASSIGNEE_ID,
+  reporter_id: ACTOR_ID,
+  priority: 'medium',
+  story_points: null,
+  time_estimate_minutes: null,
+  start_date: null,
+  due_date: null,
+  completed_at: null,
+  labels: [],
+  custom_fields: {},
+  subtask_count: 0,
+  position: 1024,
+  created_at: now,
+  updated_at: now,
+};
+
+// ---------- helpers ----------
+function setupTaskUpdate(taskOverrides: Partial<typeof fakeTask> = {}) {
+  const returning = vi.fn().mockResolvedValue([{ ...fakeTask, ...taskOverrides }]);
+  const where = vi.fn().mockReturnValue({ returning });
+  const set = vi.fn().mockReturnValue({ where });
+  mockDb.update.mockReturnValue({ set });
+}
+
+function setupOrgSelect() {
+  const limit = vi.fn().mockResolvedValue([{ org_id: ORG_ID }]);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  mockDb.select.mockReturnValue({ from });
+}
+
+function setupEnrichers(assignee: object | null = {
+  id: ASSIGNEE_ID,
+  email: 'assignee@example.com',
+  name: 'Assignee User',
+}) {
+  vi.mocked(enrichTask).mockResolvedValue({
+    task: fakeTask,
+    project: { id: PROJECT_ID, name: 'Test Project' },
+    phase: null,
+    sprint: null,
+    epic: null,
+    assignee,
+    reporter: null,
+  } as any);
+  vi.mocked(loadActor).mockResolvedValue({ id: ACTOR_ID, name: 'Actor User' } as any);
+  vi.mocked(loadOrg).mockResolvedValue({ id: ORG_ID, name: 'Test Org' } as any);
+}
+
+// Wait for the fire-and-forget Bolt block to complete.
+// publishBoltEvent is called synchronously inside it, so once it's been
+// called we know all the code in the .then() callback has run.
+async function waitForBoltBlock() {
+  await vi.waitFor(() => {
+    expect(vi.mocked(publishBoltEvent)).toHaveBeenCalled();
+  }, { timeout: 2000 });
+}
+
+// ---------- tests ----------
+describe('task assignment → notifications queue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enqueues a job to the notifications queue when assignee_id changes', async () => {
+    setupTaskUpdate({ assignee_id: ASSIGNEE_ID });
+    setupOrgSelect();
+    setupEnrichers();
+
+    await updateTask(TASK_ID, { assignee_id: ASSIGNEE_ID }, ACTOR_ID);
+
+    await vi.waitFor(() => {
+      expect(mockQueueAdd['notifications']).toBeDefined();
+      expect(mockQueueAdd['notifications']).toHaveBeenCalled();
+    }, { timeout: 2000 });
+  });
+
+  it('notification job payload includes user_id, task_id, project_id, type, category, and source_app', async () => {
+    setupTaskUpdate({ assignee_id: ASSIGNEE_ID });
+    setupOrgSelect();
+    setupEnrichers();
+
+    await updateTask(TASK_ID, { assignee_id: ASSIGNEE_ID }, ACTOR_ID);
+
+    await vi.waitFor(() => {
+      expect(mockQueueAdd['notifications']).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          user_id: ASSIGNEE_ID,
+          task_id: TASK_ID,
+          project_id: PROJECT_ID,
+          type: 'task.assigned',
+          category: 'assignment',
+          source_app: 'bbb',
+        }),
+        expect.any(Object),
+      );
+    }, { timeout: 2000 });
+  });
+
+  it('does not enqueue when no assignee_id in the update', async () => {
+    setupTaskUpdate();
+    setupOrgSelect();
+    setupEnrichers();
+
+    await updateTask(TASK_ID, { title: 'Renamed task' }, ACTOR_ID);
+    await waitForBoltBlock();
+
+    expect(mockQueueAdd['notifications']?.mock?.calls ?? []).toHaveLength(0);
+  });
+
+  it('does not enqueue when actor is the new assignee (self-assignment)', async () => {
+    setupTaskUpdate({ assignee_id: ACTOR_ID });
+    setupOrgSelect();
+    setupEnrichers({ id: ACTOR_ID, email: 'actor@example.com', name: 'Actor User' });
+
+    await updateTask(TASK_ID, { assignee_id: ACTOR_ID }, ACTOR_ID);
+    await waitForBoltBlock();
+
+    expect(mockQueueAdd['notifications']?.mock?.calls ?? []).toHaveLength(0);
+  });
+});

--- a/apps/worker/src/jobs/notification.job.ts
+++ b/apps/worker/src/jobs/notification.job.ts
@@ -2,21 +2,15 @@ import type { Job } from 'bullmq';
 import type { Logger } from 'pino';
 import { sql } from 'drizzle-orm';
 import { getDb } from '../utils/db.js';
+import type { NotificationJobData } from '@bigbluebam/shared';
 
-export interface NotificationJobData {
-  user_id: string;
-  project_id: string;
-  task_id?: string;
-  type: string;
-  title: string;
-  body: string;
-}
+export type { NotificationJobData };
 
 export async function processNotificationJob(
   job: Job<NotificationJobData>,
   logger: Logger,
 ): Promise<void> {
-  const { user_id, project_id, task_id, type, title, body } = job.data;
+  const { user_id, project_id, task_id, type, title, body, category, source_app, deep_link } = job.data;
 
   logger.info(
     { jobId: job.id, user_id, project_id, type, title },
@@ -26,7 +20,7 @@ export async function processNotificationJob(
   const db = getDb();
 
   await db.execute(sql`
-    INSERT INTO notifications (id, user_id, project_id, task_id, type, title, body, is_read, created_at)
+    INSERT INTO notifications (id, user_id, project_id, task_id, type, title, body, category, source_app, deep_link, is_read, created_at)
     VALUES (
       gen_random_uuid(),
       ${user_id},
@@ -35,6 +29,9 @@ export async function processNotificationJob(
       ${type},
       ${title},
       ${body},
+      ${category ?? null},
+      ${source_app ?? 'bbb'},
+      ${deep_link ?? null},
       false,
       NOW()
     )

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -282,3 +282,16 @@ export type BearingGoalScopeInput = z.infer<typeof import('../schemas/bearing.js
 export type BearingGoalStatusInput = z.infer<typeof import('../schemas/bearing.js').BearingGoalStatus>;
 export type BearingMetricTypeInput = z.infer<typeof import('../schemas/bearing.js').BearingMetricType>;
 export type BearingProgressModeInput = z.infer<typeof import('../schemas/bearing.js').BearingProgressMode>;
+
+// ── Notification queue types ────────────────────────────────────────────
+export interface NotificationJobData {
+  user_id: string;
+  project_id: string;
+  task_id?: string;
+  type: string;
+  title: string;
+  body: string;
+  category?: string;
+  source_app?: string;
+  deep_link?: string;
+}


### PR DESCRIPTION
Fixes leith-bartrich/BigBlueBam#2.

> **Depends on #29.** This PR uses `enqueueNotification` and `NotificationJobData` introduced there. Merge #29 first.

## Problem

When an admin adds a user to a project via `addProjectMember`, no activity log entry is written and nothing is enqueued to the `notifications` queue. The new member sees no notification in their feed, and the project's activity history has no record of the membership change.

## Approach (TDD)

Tests were written first to expose both gaps (`test/project-membership-notification.test.ts`):

- calls `logActivity` with `member.added` when actorId is provided
- enqueues a job to the `notifications` BullMQ queue for the new member
- notification payload has correct `category: 'membership_added'` and `source_app: 'bbb'`
- does **not** enqueue when no actorId is provided

All four tests were confirmed red before any source changes, then the fix was applied to make them green.

## Changes

**`apps/api/src/services/project.service.ts`**
- `addProjectMember` gains an optional `actorId` parameter
- When `actorId` is present: calls `logActivity('member.added')` (fire-and-forget) and enqueues a `notifications` job with project name + actor name looked up via `Promise.all` (also fire-and-forget, never blocks the HTTP response)

**`apps/api/src/routes/project.routes.ts`**
- Route handler passes `request.user.id` as `actorId`

## Suggested follow-on

`apps/worker/src/jobs/notification.job.ts` uses a raw `db.execute(sql\`...\`)` to insert notification rows rather than Drizzle's typed query builder. Making it consistent with the rest of the codebase would be a good standalone cleanup PR.