### PR TITLE
fix(beacon-api): replace hardcoded date in expiry-sweep test

### DIFF
--- a/apps/beacon-api/test/graph.test.ts
+++ b/apps/beacon-api/test/graph.test.ts
@@ -377,7 +377,7 @@ describe('beacon-expiry-sweep', () => {
     const draft = {
       id: BEACON_D,
       status: 'Draft',
-      created_at: new Date('2026-03-15'), // ~21 days ago
+      created_at: new Date(Date.now() - 21 * 86_400_000), // 21 days ago — always inside the 60-day window
     };
 
     const sixtyDaysAgo = new Date(Date.now() - 60 * 86_400_000);


### PR DESCRIPTION
Fixes #33.

The "does not delete drafts under 60 days old" test used a hardcoded `created_at: new Date('2026-03-15')`. That date is now >60 days in the past, so the assertion that it falls *inside* the 60-day window fails.

Replaced with `new Date(Date.now() - 21 * 86_400_000)` — 21 days ago relative to test runtime — which always satisfies the invariant the test is actually checking (a recently-created draft should not be a sweep candidate).

The companion test ("identifies stale drafts older than 60 days", `2026-01-15`) asserts `LessThan` and remains correct indefinitely, so only this one needed changing.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)