### PR TITLE
fix(api): version-check should compare against stable, not main

### DIFF
--- a/apps/api/src/services/version-check.service.ts
+++ b/apps/api/src/services/version-check.service.ts
@@ -1,7 +1,8 @@
-// Checks GitHub API for latest commit on main branch.
+// Checks GitHub API for latest commit on stable branch.
 // Cached — refreshes every 6 hours. No git binary needed.
 
 const GITHUB_REPO = 'eoffermann/BigBlueBam';
+const GITHUB_BRANCH = 'stable';
 const CHECK_INTERVAL = 6 * 60 * 60 * 1000; // 6 hours
 
 let cache: { sha: string; date: string; message: string } | null = null;
@@ -9,7 +10,7 @@ let lastCheck = 0;
 
 async function fetchLatestRemoteCommit() {
   try {
-    const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/commits/main`, {
+    const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/commits/${GITHUB_BRANCH}`, {
       headers: { Accept: 'application/vnd.github.v3+json', 'User-Agent': 'BigBlueBam-VersionCheck' },
       signal: AbortSignal.timeout(10000),
     });


### PR DESCRIPTION
## What this fixes

`apps/api/src/services/version-check.service.ts` hardcodes a check against `main`:

```ts
const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/commits/main`, ...);
```

The deploy script defaults to and recommends deploying from `stable`. Any operator following that recommendation will have their running `GIT_COMMIT` permanently differ from `main`'s HEAD — so `update_available` is always `true` and the superuser update banner never clears.

The bug goes beyond noise: the banner is effectively telling operators to update to a version of the codebase that the deploy script itself classifies as unstable. The deploy script recommends `stable`; the version check points at `main`. Those two signals directly contradict each other.

This PR fixes the inconsistency by changing the hardcoded branch from `main` to `stable`, so the update signal tracks the same branch the deploy script recommends. The `'stable'` string is extracted to a named `GITHUB_BRANCH` constant for clarity, but it is not configurable — this is purely a correctness fix.

## Scope

Intentionally minimal — one constant changed, no new env vars, no API shape changes.

## Follow-up work worth considering

This fix exposes a broader design gap that a future PR could address:

- **Custom deployment branches**: operators running forks or long-lived branches have no way to point the check at their own repo/branch. `VERSION_CHECK_REPO` and `VERSION_CHECK_BRANCH` env vars, baked at deploy time by the deploy script, would cover this.

- **Richer divergence expression**: `update_available` is a bare boolean with no context. A more useful response would express divergence relative to `stable`, `main`, and any custom branch separately — "you're current on stable, but main has 12 new commits."

- **Release tag consideration**: the current model is commit-hash based. Comparing against a semver tag on `stable` could give a more meaningful signal and allow release notes linkage. Worth noting however that tag-based update checks carry their own supply chain considerations and would warrant careful design before adopting.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)