### PR TITLE
fix(seed): seed scripts broken after Wave E.F role column drop

### DIFF
--- a/scripts/seed-acme-scenario.mjs
+++ b/scripts/seed-acme-scenario.mjs
@@ -42,6 +42,19 @@ const DATABASE_URL =
 
 const sql = postgres(DATABASE_URL, { max: 2 });
 
+// Built-in permission-group UUIDs seeded by migration 0146. The per-org role
+// dropped off `users` / `organization_memberships` in migration 0159 and now
+// lives in `account_group_memberships → permission_groups.legacy_role`.
+// Mirrors the constant in apps/api/src/cli.ts + services/role-resolver.ts +
+// scripts/seed-platform.mjs.
+const BUILTIN_GROUP_IDS = {
+  owner: '11111111-1111-4111-8111-111111111111',
+  admin: '22222222-2222-4222-8222-222222222222',
+  member: '33333333-3333-4333-8333-333333333333',
+  viewer: '44444444-4444-4444-8444-444444444444',
+  guest: '55555555-5555-4555-8555-555555555555',
+};
+
 // ─── helpers ──────────────────────────────────────────────────────────────
 
 function uuid() {
@@ -854,11 +867,17 @@ async function main() {
   }
   console.log(`Acme scenario seed: org "${org.name}" (${org.slug}) ${org.id}`);
 
-  // Admin user (reporter + owner for everything).
+  // Admin user (reporter + owner for everything). Wave E.F: org role lives
+  // in account_group_memberships → permission_groups, identified by the
+  // fixed owner group UUID (seeded by migration 0146).
   const [admin] = await sql`
-    SELECT id, email FROM users
-    WHERE org_id = ${org.id} AND role = 'owner'
-    ORDER BY created_at LIMIT 1
+    SELECT u.id, u.email FROM users u
+    JOIN account_group_memberships agm
+      ON agm.user_id = u.id
+     AND agm.scope_type = 'org'
+     AND agm.scope_id = ${org.id}
+    WHERE u.org_id = ${org.id} AND agm.group_id = ${BUILTIN_GROUP_IDS.owner}
+    ORDER BY u.created_at LIMIT 1
   `;
   if (!admin) {
     console.error('No owner user found. Run seed-platform first.');

--- a/scripts/seed-platform.mjs
+++ b/scripts/seed-platform.mjs
@@ -39,6 +39,18 @@ const sql = postgres(DATABASE_URL, { max: 2 });
 
 const DEFAULT_PASSWORD = 'dev-password-change-me';
 
+// Built-in permission-group UUIDs seeded by migration 0146. The per-org role
+// dropped off `users` / `organization_memberships` in migration 0159 and now
+// lives in `account_group_memberships → permission_groups.legacy_role`.
+// Mirrors the constant in apps/api/src/cli.ts + services/role-resolver.ts.
+const BUILTIN_GROUP_IDS = {
+  owner: '11111111-1111-4111-8111-111111111111',
+  admin: '22222222-2222-4222-8222-222222222222',
+  member: '33333333-3333-4333-8333-333333333333',
+  viewer: '44444444-4444-4444-8444-444444444444',
+  guest: '55555555-5555-4555-8555-555555555555',
+};
+
 // ─── helpers ──────────────────────────────────────────────────────────────
 
 function uuid() {
@@ -64,32 +76,53 @@ function dateOnly(d) {
 // ─── users ────────────────────────────────────────────────────────────────
 
 async function ensureUser(orgId, spec) {
+  const groupId = BUILTIN_GROUP_IDS[spec.role];
+  if (!groupId) {
+    throw new Error(`Unknown role for ${spec.email}: ${spec.role}`);
+  }
+
   const [existing] = await sql`
-    SELECT id, email, role FROM users WHERE email = ${spec.email} LIMIT 1
+    SELECT id, email FROM users WHERE email = ${spec.email} LIMIT 1
   `;
   if (existing) {
     // Make sure the user is a member of the target org. This handles the
     // case where a platform seed ran earlier against a different org.
     await sql`
-      INSERT INTO organization_memberships (user_id, org_id, role, is_default)
-      VALUES (${existing.id}, ${orgId}, ${spec.role}, false)
+      INSERT INTO organization_memberships (user_id, org_id, is_default)
+      VALUES (${existing.id}, ${orgId}, false)
       ON CONFLICT (user_id, org_id) DO NOTHING
     `;
-    return { id: existing.id, email: existing.email, role: existing.role, isNew: false };
+    await sql`
+      INSERT INTO account_group_memberships (user_id, group_id, scope_type, scope_id)
+      VALUES (${existing.id}, ${groupId}, 'org', ${orgId})
+      ON CONFLICT (user_id, scope_type, scope_id) DO UPDATE
+        SET group_id = EXCLUDED.group_id,
+            detached_at = NULL,
+            detached_by = NULL
+    `;
+    return { id: existing.id, email: existing.email, role: spec.role, isNew: false };
   }
 
   const passwordHash = await argon2.hash(DEFAULT_PASSWORD);
   const [user] = await sql`
-    INSERT INTO users (org_id, email, display_name, password_hash, role, is_superuser)
-    VALUES (${orgId}, ${spec.email}, ${spec.displayName}, ${passwordHash}, ${spec.role}, false)
-    RETURNING id, email, role
+    INSERT INTO users (org_id, email, display_name, password_hash, is_superuser)
+    VALUES (${orgId}, ${spec.email}, ${spec.displayName}, ${passwordHash}, false)
+    RETURNING id, email
   `;
   await sql`
-    INSERT INTO organization_memberships (user_id, org_id, role, is_default)
-    VALUES (${user.id}, ${orgId}, ${spec.role}, true)
+    INSERT INTO organization_memberships (user_id, org_id, is_default)
+    VALUES (${user.id}, ${orgId}, true)
     ON CONFLICT (user_id, org_id) DO NOTHING
   `;
-  return { id: user.id, email: user.email, role: user.role, isNew: true };
+  await sql`
+    INSERT INTO account_group_memberships (user_id, group_id, scope_type, scope_id)
+    VALUES (${user.id}, ${groupId}, 'org', ${orgId})
+    ON CONFLICT (user_id, scope_type, scope_id) DO UPDATE
+      SET group_id = EXCLUDED.group_id,
+          detached_at = NULL,
+          detached_by = NULL
+  `;
+  return { id: user.id, email: user.email, role: spec.role, isNew: true };
 }
 
 // ─── projects ─────────────────────────────────────────────────────────────
@@ -489,7 +522,7 @@ async function main() {
   // Pull every user in the org, including the pre-existing admin, for the
   // round-robin assignment pool.
   const allUsersRows = await sql`
-    SELECT u.id, u.email, u.display_name, u.role
+    SELECT u.id, u.email, u.display_name
     FROM users u
     JOIN organization_memberships m ON m.user_id = u.id
     WHERE m.org_id = ${org.id} AND u.is_active = true
@@ -499,15 +532,20 @@ async function main() {
     id: u.id,
     email: u.email,
     displayName: u.display_name,
-    role: u.role,
   }));
   console.log(`  total active users in org: ${users.length}`);
 
   // The admin from create-admin is the canonical reporter / creator.
+  // Wave E.F: org role lives in account_group_memberships → permission_groups,
+  // identified by the fixed owner group UUID (seeded by migration 0146).
   const [adminUser] = await sql`
     SELECT u.id FROM users u
     JOIN organization_memberships m ON m.user_id = u.id
-    WHERE m.org_id = ${org.id} AND (u.role = 'owner' OR m.role = 'owner')
+    JOIN account_group_memberships agm
+      ON agm.user_id = u.id
+     AND agm.scope_type = 'org'
+     AND agm.scope_id = ${org.id}
+    WHERE m.org_id = ${org.id} AND agm.group_id = ${BUILTIN_GROUP_IDS.owner}
     ORDER BY m.joined_at
     LIMIT 1
   `;


### PR DESCRIPTION
Closes #36.

## Problem

Migration `0159_permissions_drop_legacy_role_columns.sql` (Wave E.F) dropped `users.role` and `organization_memberships.role`. The companion update landed in `apps/api/src/cli.ts` (`create-admin`, `create-user`), but two raw-SQL seed scripts were missed and now crash immediately:

```
Platform seed FATAL: PostgresError: column "role" does not exist
    at ensureUser (.../scripts/seed-platform.mjs:67:31)
```

This blocks anyone following the documented Step 5b of `docs/guides/getting-started.md` (`docker compose --profile seed run --rm seed`) on a fresh post-Wave-E.F clone.

## Files changed

- `scripts/seed-platform.mjs` — three sites:
  - `ensureUser()` (lines 66-93): dropped `role` from `INSERT INTO users` and `INSERT INTO organization_memberships`; after the user+membership inserts, upsert `account_group_memberships` keyed by `BUILTIN_GROUP_IDS[spec.role]` with `scope_type='org'`, `scope_id=orgId`. ON CONFLICT clears any stale `detached_at`/`detached_by` so a previously-detached membership snaps back to the live group on re-run.
  - Bulk users SELECT (lines 491-503): dropped `u.role` from the projection. Verified locally that nothing downstream reads `users[i].role` — it was dead data even before 0159.
  - Owner lookup (lines 507-513): replaced the `(u.role = 'owner' OR m.role = 'owner')` clause with a JOIN through `account_group_memberships` filtered by `group_id = BUILTIN_GROUP_IDS.owner`.

- `scripts/seed-acme-scenario.mjs` — one site:
  - Owner lookup at line 860: same fix as `seed-platform.mjs`'s owner lookup. Without this, Phase D of the seed orchestrator failed even after `seed-platform.mjs` was fixed.

`BUILTIN_GROUP_IDS` is duplicated as a top-level const in both scripts to mirror the pattern in `apps/api/src/cli.ts:16-23` rather than introducing a shared helper module — two call sites is below my abstraction threshold; if a third seeder ever needs it, extract.

Note: `project_memberships.role`, `bond_deal_contacts.role`, and `banter_channel_memberships.role` were **not** dropped by 0159 and remain unchanged in both files.

## Test plan

Verified on a fresh dev stack (full decommission + fresh `.env` + fresh `pgdata` volume):

- [x] `docker compose --profile seed run --rm seed` exits 0
- [x] `./scripts/dev/fixture-base.sh` exits 0 with `ok: 15, skipped: 0, failed: 0` (was `failed: 1` after only the `seed-platform.mjs` fix)
- [x] Postgres spot-check confirms all 8 seeded users mapped to correct legacy roles via the new join:

  ```
                  email                 | legacy_role
  --------------------------------------+-------------
   admin@example.com                    | owner
   alice@example.com                    | admin
   bob@example.com                      | member
   carol@example.com                    | member
   dave@example.com                     | member
   eve@example.com                      | viewer
   frank@example.com                    | member
   system-bootstrap@bigbluebam.internal | owner
  ```

- [x] `bash scripts/dev/test.sh` still 44/44 turbo tasks green (the mocked-test baseline doesn't exercise seed scripts but is a sanity check that this PR didn't touch anything else).

## Related

A follow-up issue will be filed separately about why this slipped past CI — no workflow in `.github/workflows/` currently exercises the seed sidecar, so any future column drop/rename that updates Drizzle + `cli.ts` but not the raw-SQL seeders can ship green. Discussed in the comment thread on #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)